### PR TITLE
Added helper functions to support fine grained control over the cache

### DIFF
--- a/cachetools/decorators.py
+++ b/cachetools/decorators.py
@@ -91,6 +91,28 @@ def cachedmethod(cache, typed=False):
                 pass  # value too large
             return result
 
+        def cache_invalidate(self, *args, **kwargs):
+            mapping = wrapper.cache(self)
+            if mapping is None:
+                return
+            key = makekey((method,) + args, kwargs)
+            try:
+                del mapping[key]
+            except KeyError:
+                pass
+
+        def cache_set(self, value, *args, **kwargs):
+            mapping = wrapper.cache(self)
+            if mapping is None:
+                return
+            key = makekey((method,) + args, kwargs)
+            try:
+                mapping[key] = value
+            except ValueError:
+                pass # value too large
+
+        wrapper.cache_set = cache_set
+        wrapper.cache_invalidate = cache_invalidate
         wrapper.cache = cache
         return functools.update_wrapper(wrapper, method)
 


### PR DESCRIPTION
Hi,

I found usefull the following two cases for method calls, but I think they might be useful for function calls as well:
1. Invalidating only one entry in the cache.
2. Setting manually a cache entry, given the parameters of the method call

Here is an example of how I see it being used:

``` python
class Cached(object):
    def __init__(self):
        self._cache = LRUCache(maxsize=100)

    @cachedmethod(operator.attrgetter('_cache'))
    def get_id(self, id):
        return expensive_call(uuid)

    def set_id(self, id, value):
        self.fast_get.cache_set(self, value, id)

    def del_id(self, id):
        self.fast_get.cache_invalidate(self, id)
```

Tell me what you think, and I will update the function decorator as well, if you decide to merge my commit.

Cheers,
Vlad