### PR TITLE
Allow pickling simple instances of caches.

### DIFF
--- a/cachetools/cache.py
+++ b/cachetools/cache.py
@@ -9,7 +9,7 @@ class Cache(collections.MutableMapping):
         self.__currsize = 0
         self.__maxsize = maxsize
         self.__missing = missing
-        self.__getsizeof = getsizeof or (lambda x: 1)
+        self.__getsizeof = getsizeof
 
     def __repr__(self):
         return '%s(%r, maxsize=%d, currsize=%d)' % (
@@ -28,7 +28,7 @@ class Cache(collections.MutableMapping):
     def __setitem__(self, key, value):
         data = self.__data
         maxsize = self.__maxsize
-        size = self.__getsizeof(value)
+        size = 1 if self.__getsizeof is None else self.__getsizeof(value)
         if size > maxsize:
             raise ValueError('value too large')
         if key not in data or data[key][1] < size:
@@ -75,7 +75,9 @@ class Cache(collections.MutableMapping):
 
     def getsizeof(self, value):
         """Return the size of a cache element's value."""
-        return self.__getsizeof(value)
+        if self.__getsizeof:
+            return self.__getsizeof(value)
+        return 1
 
     # collections.MutableMapping mixin methods do not handle __missing__
 

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -16,14 +16,19 @@ class LRUCache(Cache):
     """Least Recently Used (LRU) cache implementation."""
 
     def __init__(self, maxsize, missing=None, getsizeof=None):
+        self.__getsizeoflink = None
         if getsizeof is not None:
-            getlinksize = lambda link: getsizeof(link.value)
-            Cache.__init__(self, maxsize, missing, getlinksize)
-            self.getsizeof = getsizeof
+            Cache.__init__(self, maxsize, missing, lambda link: getsizeof(link.value))
+            self.__getsizeoflink = getsizeof
         else:
             Cache.__init__(self, maxsize, missing)
         self.__root = root = Link()
         root.prev = root.next = root
+
+    def getsizeof(self, value):
+        if self.__getsizeoflink:
+            return self.__getsizeoflink(value)
+        return Cache.getsizeof(self, value)
 
     def __repr__(self, cache_getitem=Cache.__getitem__):
         # prevent item reordering

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -50,6 +50,9 @@ class NestedTimer(object):
 
     def __getattr__(self, name):
         # FIXME: for unittests timer.tick()
+        if name == '__setstate__':
+            # For pickling: without this we see infinite recursion.
+            return None
         return getattr(self.__timer, name)
 
 

--- a/tests/test_lfu.py
+++ b/tests/test_lfu.py
@@ -52,3 +52,19 @@ class LFUCacheTest(unittest.TestCase, CacheTestMixin, DecoratorTestMixin):
             cache[4] = 4
         self.assertEqual(len(cache), 1)
         self.assertEqual(cache[3], 3)
+
+    def test_lfu_pickle(self):
+        import pickle
+
+        cache = self.cache(maxsize=3)
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(0, len(unpickled))
+
+        cache[1] = 1
+        cache[2] = 2
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(2, len(unpickled))
+        self.assertEquals(1, unpickled[1])
+        self.assertEquals(2, unpickled[2])

--- a/tests/test_lru.py
+++ b/tests/test_lru.py
@@ -59,3 +59,19 @@ class LRUCacheTest(unittest.TestCase, CacheTestMixin, DecoratorTestMixin):
             cache[4] = 4
         self.assertEqual(len(cache), 1)
         self.assertEqual(cache[3], 3)
+
+    def test_lru_pickle(self):
+        import pickle
+
+        cache = self.cache(maxsize=3)
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(0, len(unpickled))
+
+        cache[1] = 1
+        cache[2] = 2
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(2, len(unpickled))
+        self.assertEquals(1, unpickled[1])
+        self.assertEquals(2, unpickled[2])

--- a/tests/test_rr.py
+++ b/tests/test_rr.py
@@ -40,3 +40,12 @@ class RRCacheTest(unittest.TestCase, CacheTestMixin, DecoratorTestMixin):
         self.assertEqual(3, cache[3])
         self.assertEqual(4, cache[4])
         self.assertNotIn(0, cache)
+
+    def test_rr_pickle(self):
+        import pickle
+
+        cache = self.cache(maxsize=3)
+        with self.assertRaises(pickle.PicklingError):
+            # The cache's random choice function cannot be pickled.
+            # Try dill instead.
+            pickle.dumps(cache, -1)

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -189,3 +189,19 @@ class TTLCacheTest(unittest.TestCase, CacheTestMixin, DecoratorTestMixin):
         with self.assertRaises(KeyError):
             cache[(1, 2, 3)]
         self.assertNotIn((1, 2, 3), cache)
+
+    def test_ttl_pickle(self):
+        import pickle
+
+        cache = self.cache(maxsize=3)
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(0, len(unpickled))
+
+        cache[1] = 1
+        cache[2] = 2
+        unpickled = pickle.loads(pickle.dumps(cache, -1))
+        self.assertIsNotNone(unpickled)
+        self.assertEquals(2, len(unpickled))
+        self.assertEquals(1, unpickled[1])
+        self.assertEquals(2, unpickled[2])


### PR DESCRIPTION
This is not particularly robust, but it handles (and tests) the simplest
examples.  In general, pickle does not handle lambda functions, so this
is about the best that can be done.  It's worth noting that this uses
a non-default pickle protocol: the regular one fails due to __slots__
with no __getstate__ implementation.  This non-default protocol is
specified with dumps(cache, -1): the -1 means "latest".

For a more robust pickling solution, try the dill module.