### PR TITLE
drop in backend storage 

### DIFF
--- a/cachetools/cache.py
+++ b/cachetools/cache.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
+from collections import MutableMapping
+
 from .abc import DefaultMapping
 
-from collections import MutableMapping
 
 class _DefaultSize(object):
     def __getitem__(self, _):
@@ -14,8 +15,8 @@ class _DefaultSize(object):
     def pop(self, _):
         return 1
 
-class CacheDict(MutableMapping):
 
+class CacheDict(MutableMapping):
     def __init__(self):
         self.store = dict()
         self.size = 0

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -8,8 +8,8 @@ from .cache import Cache
 class LRUCache(Cache):
     """Least Recently Used (LRU) cache implementation."""
 
-    def __init__(self, maxsize, missing=None, getsizeof=None):
-        Cache.__init__(self, maxsize, missing, getsizeof)
+    def __init__(self, maxsize, missing=None, getsizeof=None, data=None):
+        Cache.__init__(self, maxsize, missing, getsizeof, data)
         self.__order = collections.OrderedDict()
 
     def __getitem__(self, key, cache_getitem=Cache.__getitem__):

--- a/tests/test_lru_persist.py
+++ b/tests/test_lru_persist.py
@@ -1,8 +1,8 @@
 import unittest
 
-from cachetools import LRUCache
-
 from pickle import dumps, loads
+
+from cachetools import LRUCache
 
 from . import CacheTestMixin
 
@@ -10,7 +10,8 @@ from . import CacheTestMixin
 class LRUCachePersistTest(unittest.TestCase, CacheTestMixin):
 
     def cache(self, maxsize, missing=None, getsizeof=None, data=None):
-        return LRUCache(maxsize, missing=missing, getsizeof=getsizeof, data=data)
+        return LRUCache(maxsize, missing=missing, getsizeof=getsizeof,
+                        data=data)
 
     def test_lru(self):
         cache = self.cache(maxsize=2)
@@ -46,7 +47,3 @@ class LRUCachePersistTest(unittest.TestCase, CacheTestMixin):
         self.assertEqual(cache2[4], 4)
         self.assertEqual(cache2[5], 5)
         self.assertNotIn(2, cache2)
-
-
-
-

--- a/tests/test_lru_persist.py
+++ b/tests/test_lru_persist.py
@@ -1,0 +1,52 @@
+import unittest
+
+from cachetools import LRUCache
+
+from pickle import dumps, loads
+
+from . import CacheTestMixin
+
+
+class LRUCachePersistTest(unittest.TestCase, CacheTestMixin):
+
+    def cache(self, maxsize, missing=None, getsizeof=None, data=None):
+        return LRUCache(maxsize, missing=missing, getsizeof=getsizeof, data=data)
+
+    def test_lru(self):
+        cache = self.cache(maxsize=2)
+
+        cache[1] = 1
+        cache[2] = 2
+        cache[3] = 3
+
+        self.assertEqual(len(cache), 2)
+        self.assertEqual(cache[2], 2)
+        self.assertEqual(cache[3], 3)
+        self.assertNotIn(1, cache)
+
+        cache[2]
+        cache[4] = 4
+        self.assertEqual(len(cache), 2)
+        self.assertEqual(cache[2], 2)
+        self.assertEqual(cache[4], 4)
+        self.assertNotIn(3, cache)
+
+        cache[5] = 5
+        self.assertEqual(len(cache), 2)
+        self.assertEqual(cache[4], 4)
+        self.assertEqual(cache[5], 5)
+        self.assertNotIn(2, cache)
+
+        # pickle/unpickle - check cache persists
+        data_pickled = dumps(cache.data)
+        data_unpickled = loads(data_pickled)
+
+        cache2 = self.cache(maxsize=2, data=data_unpickled)
+        self.assertEqual(len(cache2), 2)
+        self.assertEqual(cache2[4], 4)
+        self.assertEqual(cache2[5], 5)
+        self.assertNotIn(2, cache2)
+
+
+
+


### PR DESCRIPTION
It would be useful to persist caching across different invocations of python interpreter. The following pull request adds a data parameter to Cache that allows one to specify a previously saved store (accessible by Cache.data attribute). This data can be pickled to file and unpickled later. The data attribute is of new type CacheDict, this can be overloaded to allow caching to database or other backend. 

Let me know what you think. 