### PR TITLE
Split some methods in the TTLCache

### DIFF
--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -212,7 +212,9 @@ class TTLCache(Cache):
             self.__links[key] = value
             return value
 
-    def _delete_without_expiration_validation(self, key, cache_delitem=Cache.__delitem__):
+    def _delete_without_expiration_validation(self,
+                                              key,
+                                              cache_delitem=Cache.__delitem__):
         cache_delitem(self, key)
         link = self.__links.pop(key)
         link.unlink()


### PR DESCRIPTION
Just split some methods in the TTLCache so it will be easier to override from potential inherit classes.
(Of course, the logic has not changed at all)
https://github.com/tkem/cachetools/issues/125