### PR TITLE
Drop support for Python 2.7 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: true
-
 dist: xenial
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 3.6
 - 3.7
 - 3.8-dev
-- pypy3.5
+- pypy3
 
 install:
 - pip install coveralls tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 
 python:
-- 2.7
-- 3.4
 - 3.5
 - 3.6
 - 3.7

--- a/cachetools/__init__.py
+++ b/cachetools/__init__.py
@@ -1,7 +1,5 @@
 """Extensible memoizing collections and decorators."""
 
-from __future__ import absolute_import
-
 import functools
 
 from . import keys

--- a/cachetools/__init__.py
+++ b/cachetools/__init__.py
@@ -16,14 +16,6 @@ __all__ = (
 
 __version__ = '3.1.1'
 
-if hasattr(functools.update_wrapper(lambda f: f(), lambda: 42), '__wrapped__'):
-    _update_wrapper = functools.update_wrapper
-else:
-    def _update_wrapper(wrapper, wrapped):
-        functools.update_wrapper(wrapper, wrapped)
-        wrapper.__wrapped__ = wrapped
-        return wrapper
-
 
 def cached(cache, key=keys.hashkey, lock=None):
     """Decorator to wrap a function with a memoizing callable that saves
@@ -62,7 +54,7 @@ def cached(cache, key=keys.hashkey, lock=None):
                 except ValueError:
                     pass  # value too large
                 return v
-        return _update_wrapper(wrapper, func)
+        return functools.update_wrapper(wrapper, func)
     return decorator
 
 
@@ -106,5 +98,5 @@ def cachedmethod(cache, key=keys.hashkey, lock=None):
                 except ValueError:
                     pass  # value too large
                 return v
-        return _update_wrapper(wrapper, method)
+        return functools.update_wrapper(wrapper, method)
     return decorator

--- a/cachetools/abc.py
+++ b/cachetools/abc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from abc import abstractmethod
 from collections.abc import MutableMapping
 

--- a/cachetools/abc.py
+++ b/cachetools/abc.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 
 from abc import abstractmethod
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class DefaultMapping(MutableMapping):

--- a/cachetools/cache.py
+++ b/cachetools/cache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .abc import DefaultMapping
 
 

--- a/cachetools/func.py
+++ b/cachetools/func.py
@@ -5,11 +5,7 @@ from __future__ import absolute_import
 import collections
 import functools
 import random
-
-try:
-    from time import monotonic as default_timer
-except ImportError:
-    from time import time as default_timer
+from time import monotonic as default_timer
 
 try:
     from threading import RLock
@@ -85,8 +81,6 @@ def _cache(cache, typed=False):
                 pass  # value too large
             return v
         functools.update_wrapper(wrapper, func)
-        if not hasattr(wrapper, '__wrapped__'):
-            wrapper.__wrapped__ = func  # Python 2.7
         wrapper.cache_info = cache_info
         wrapper.cache_clear = cache_clear
         return wrapper

--- a/cachetools/func.py
+++ b/cachetools/func.py
@@ -1,7 +1,5 @@
 """`functools.lru_cache` compatible memoizing function decorators."""
 
-from __future__ import absolute_import
-
 import collections
 import functools
 import random

--- a/cachetools/keys.py
+++ b/cachetools/keys.py
@@ -1,7 +1,5 @@
 """Key functions for memoizing decorators."""
 
-from __future__ import absolute_import
-
 __all__ = ('hashkey', 'typedkey')
 
 

--- a/cachetools/lfu.py
+++ b/cachetools/lfu.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 
 from .cache import Cache

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 
 from .cache import Cache

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -32,15 +32,8 @@ class LRUCache(Cache):
         else:
             return (key, self.pop(key))
 
-    if hasattr(collections.OrderedDict, 'move_to_end'):
-        def __update(self, key):
-            try:
-                self.__order.move_to_end(key)
-            except KeyError:
-                self.__order[key] = None
-    else:
-        def __update(self, key):
-            try:
-                self.__order[key] = self.__order.pop(key)
-            except KeyError:
-                self.__order[key] = None
+    def __update(self, key):
+        try:
+            self.__order.move_to_end(key)
+        except KeyError:
+            self.__order[key] = None

--- a/cachetools/rr.py
+++ b/cachetools/rr.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import random
 
 from .cache import Cache

--- a/cachetools/rr.py
+++ b/cachetools/rr.py
@@ -5,21 +5,13 @@ import random
 from .cache import Cache
 
 
-# random.choice cannot be pickled in Python 2.7
-def _choice(seq):
-    return random.choice(seq)
-
-
 class RRCache(Cache):
     """Random Replacement (RR) cache implementation."""
 
     def __init__(self, maxsize, choice=random.choice, getsizeof=None):
         Cache.__init__(self, maxsize, getsizeof)
         # TODO: use None as default, assing to self.choice directly?
-        if choice is random.choice:
-            self.__choice = _choice
-        else:
-            self.__choice = choice
+        self.__choice = choice
 
     @property
     def choice(self):

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -202,13 +202,7 @@ class TTLCache(Cache):
             else:
                 return (key, self.pop(key))
 
-    if hasattr(collections.OrderedDict, 'move_to_end'):
-        def __getlink(self, key):
-            value = self.__links[key]
-            self.__links.move_to_end(key)
-            return value
-    else:
-        def __getlink(self, key):
-            value = self.__links.pop(key)
-            self.__links[key] = value
-            return value
+    def __getlink(self, key):
+        value = self.__links[key]
+        self.__links.move_to_end(key)
+        return value

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 
 import collections
-
-try:
-    from time import monotonic as default_timer
-except ImportError:
-    from time import time as default_timer
+from time import monotonic as default_timer
 
 from .cache import Cache
 

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 from time import monotonic as default_timer
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     long_description=open('README.rst').read(),
     keywords='cache caching memoize memoizing memoization LRU LFU TTL',
     packages=find_packages(exclude=['tests', 'tests.*']),
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Other Environment',
@@ -26,13 +27,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -115,7 +115,7 @@ class CachedMethodTest(unittest.TestCase):
         import fractions
         import gc
 
-        # in Python 3.4, `int` does not support weak references even
+        # `int` does not support weak references even
         # when subclassed, but Fraction apparently does...
         class Int(fractions.Fraction):
             def __add__(self, other):


### PR DESCRIPTION
Fixes #143. 

Also upgrade tested PyPy3 from Python 3.5.3/PyPy 5.10.1 to Python 3.6.1/PyPy 7.1.1-beta0.
