### PR TITLE
Add per key custom TTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build/
 dist/
 docs/_build/
 .pytest_cache/
+.env
+.vscode
+.pytest_cache
+.mypy_cache

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -83,7 +83,8 @@ class TTLCache(Cache):
         else:
             return cache_getitem(self, key)
 
-    def __setitem__(self, key, value, cache_setitem=Cache.__setitem__):
+    def __setitem__(self, key, value, ttl=None,
+                    cache_setitem=Cache.__setitem__):
         with self.__timer as time:
             self.expire(time)
             cache_setitem(self, key, value)
@@ -93,7 +94,8 @@ class TTLCache(Cache):
             self.__links[key] = link = _Link(key)
         else:
             link.unlink()
-        link.expire = time + self.__ttl
+        ttl = ttl or self.__ttl
+        link.expire = time + ttl
         link.next = root = self.__root
         link.prev = prev = root.prev
         prev.next = root.prev = link
@@ -153,7 +155,7 @@ class TTLCache(Cache):
 
     @property
     def ttl(self):
-        """The time-to-live value of the cache's items."""
+        """The default time-to-live value of the cache's items."""
         return self.__ttl
 
     def expire(self, time=None):
@@ -206,3 +208,6 @@ class TTLCache(Cache):
         value = self.__links[key]
         self.__links.move_to_end(key)
         return value
+
+    def set(self, key, value, ttl=None):
+        self.__setitem__(key, value, ttl=ttl)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,6 +116,11 @@ of one argument used to retrieve the size of an item's value.
       items that have expired by the current value returned by
       :attr:`timer`.
 
+   .. method:: set(self, key, value, ttl=None)
+
+      Key in cache will be set with a custom TTL value if set. When
+      `ttl is None` the TTL for the key will default to :attr:`ttl`.
+
 
 Extending cache classes
 -----------------------

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -83,6 +83,23 @@ class TTLCacheTest(unittest.TestCase, CacheTestMixin):
         with self.assertRaises(KeyError):
             del cache[3]
 
+    def test_custom_ttl(self):
+        cache = TTLCache(maxsize=3, ttl=1, timer=Timer())
+        cache.set(1, 1)
+        cache.set(2, 2, ttl=2)
+        cache.set(3, 3)
+
+        cache.timer.tick()
+        self.assertEqual(1, cache[1])
+        self.assertEqual(2, cache[2])
+        self.assertEqual(3, cache[3])
+        cache.timer.tick()
+        self.assertNotIn(1, cache)
+        self.assertNotIn(3, cache)
+        self.assertEqual(2, cache[2])
+        cache.timer.tick()
+        self.assertNotIn(2, cache)
+
     def test_ttl_lru(self):
         cache = TTLCache(maxsize=2, ttl=0, timer=Timer())
 


### PR DESCRIPTION
Implements Issue #157 

This needed a custom `set` function in order to be able to pass an
extra argument to the cache's `__setitem__`. Also added a basic test to
demonstrate the change works and restore test coverage.