### PR TITLE
Fix exception causes

### DIFF
--- a/cachetools/lfu.py
+++ b/cachetools/lfu.py
@@ -27,7 +27,7 @@ class LFUCache(Cache):
         """Remove and return the `(key, value)` pair least frequently used."""
         try:
             (key, _), = self.__counter.most_common(1)
-        except ValueError:
-            raise KeyError('%s is empty' % self.__class__.__name__)
+        except ValueError as e:
+            raise KeyError('%s is empty' % self.__class__.__name__) from e
         else:
             return (key, self.pop(key))

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -27,8 +27,8 @@ class LRUCache(Cache):
         """Remove and return the `(key, value)` pair least recently used."""
         try:
             key = next(iter(self.__order))
-        except StopIteration:
-            raise KeyError('%s is empty' % self.__class__.__name__)
+        except StopIteration as e:
+            raise KeyError('%s is empty' % self.__class__.__name__) from e
         else:
             return (key, self.pop(key))
 

--- a/cachetools/rr.py
+++ b/cachetools/rr.py
@@ -28,7 +28,7 @@ class RRCache(Cache):
         """Remove and return a random `(key, value)` pair."""
         try:
             key = self.__choice(list(self))
-        except IndexError:
-            raise KeyError('%s is empty' % self.__class__.__name__)
+        except IndexError as e:
+            raise KeyError('%s is empty' % self.__class__.__name__) from e
         else:
             return (key, self.pop(key))

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -197,8 +197,8 @@ class TTLCache(Cache):
             self.expire(time)
             try:
                 key = next(iter(self.__links))
-            except StopIteration:
-                raise KeyError('%s is empty' % self.__class__.__name__)
+            except StopIteration as e:
+                raise KeyError('%s is empty' % self.__class__.__name__) from e
             else:
                 return (key, self.pop(key))
 


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 