### PR TITLE
Allow per-item TTL values

### DIFF
--- a/cachetools/__init__.py
+++ b/cachetools/__init__.py
@@ -5,14 +5,16 @@ from .decorators import cached, cachedmethod
 from .lfu import LFUCache
 from .lru import LRUCache
 from .rr import RRCache
-from .ttl import TTLCache
+from .ttl import FlexTTLCache, TTLCache, TTLCacheBase
 
 __all__ = (
     'Cache',
+    'FlexTTLCache',
     'LFUCache',
     'LRUCache',
     'RRCache',
     'TTLCache',
+    'TTLCacheBase',
     'cached',
     'cachedmethod'
 )


### PR DESCRIPTION
Another attempt at supporting per-item TTL values (#157). Split TTLCache
into 3 classes:

* TTLCacheBase: doesn't have any fixed TTL values and doesn't implement
full MutableMapping ABC. Instead of `__setitem__()` it has `add()` which
requires a TTL value for each item. This can be used as a base class to
implement any TTL logic.

* TTLCache: inherits from TTLCacheBase and implements the same API as
before. For advanced uses `add()` can be used directly.

* FlexTTLCache: inherits from TTLCacheBase and accepts a function to
generate TTL values per element.