### PR TITLE
Use private meta attributes rather than protected.

### DIFF
--- a/cachetools/lfu.py
+++ b/cachetools/lfu.py
@@ -8,25 +8,25 @@ class LFUCache(Cache):
 
     def __init__(self, maxsize, getsizeof=None):
         Cache.__init__(self, maxsize, getsizeof)
-        self.__counter = collections.Counter()
+        self._counter = collections.Counter()
 
     def __getitem__(self, key, cache_getitem=Cache.__getitem__):
         value = cache_getitem(self, key)
-        self.__counter[key] -= 1
+        self._counter[key] -= 1
         return value
 
     def __setitem__(self, key, value, cache_setitem=Cache.__setitem__):
         cache_setitem(self, key, value)
-        self.__counter[key] -= 1
+        self._counter[key] -= 1
 
     def __delitem__(self, key, cache_delitem=Cache.__delitem__):
         cache_delitem(self, key)
-        del self.__counter[key]
+        del self._counter[key]
 
     def popitem(self):
         """Remove and return the `(key, value)` pair least frequently used."""
         try:
-            (key, _), = self.__counter.most_common(1)
+            (key, _), = self._counter.most_common(1)
         except ValueError:
             msg = '%s is empty' % self.__class__.__name__
             raise KeyError(msg) from None

--- a/cachetools/lru.py
+++ b/cachetools/lru.py
@@ -8,7 +8,7 @@ class LRUCache(Cache):
 
     def __init__(self, maxsize, getsizeof=None):
         Cache.__init__(self, maxsize, getsizeof)
-        self.__order = collections.OrderedDict()
+        self._order = collections.OrderedDict()
 
     def __getitem__(self, key, cache_getitem=Cache.__getitem__):
         value = cache_getitem(self, key)
@@ -21,12 +21,12 @@ class LRUCache(Cache):
 
     def __delitem__(self, key, cache_delitem=Cache.__delitem__):
         cache_delitem(self, key)
-        del self.__order[key]
+        del self._order[key]
 
     def popitem(self):
         """Remove and return the `(key, value)` pair least recently used."""
         try:
-            key = next(iter(self.__order))
+            key = next(iter(self._order))
         except StopIteration:
             msg = '%s is empty' % self.__class__.__name__
             raise KeyError(msg) from None
@@ -35,6 +35,6 @@ class LRUCache(Cache):
 
     def __update(self, key):
         try:
-            self.__order.move_to_end(key)
+            self._order.move_to_end(key)
         except KeyError:
-            self.__order[key] = None
+            self._order[key] = None

--- a/cachetools/mru.py
+++ b/cachetools/mru.py
@@ -8,7 +8,7 @@ class MRUCache(Cache):
 
     def __init__(self, maxsize, getsizeof=None):
         super().__init__(maxsize, getsizeof)
-        self.__order = collections.OrderedDict()
+        self._order = collections.OrderedDict()
 
     def __getitem__(self, key):
         value = super().__getitem__(key)
@@ -21,18 +21,18 @@ class MRUCache(Cache):
 
     def __delitem__(self, key):
         super().__delitem__(key)
-        del self.__order[key]
+        del self._order[key]
 
     def popitem(self):
         """Remove and return the `(key, value)` pair most recently used."""
-        if not self.__order:
+        if not self._order:
             raise KeyError(type(self).__name__ + ' cache is empty') from None
 
-        key = next(iter(self.__order))
+        key = next(iter(self._order))
         return (key, self.pop(key))
 
     def __update(self, key):
         try:
-            self.__order.move_to_end(key, last=False)
+            self._order.move_to_end(key, last=False)
         except KeyError:
-            self.__order[key] = None
+            self._order[key] = None

--- a/cachetools/rr.py
+++ b/cachetools/rr.py
@@ -15,19 +15,19 @@ class RRCache(Cache):
         Cache.__init__(self, maxsize, getsizeof)
         # TODO: use None as default, assing to self.choice directly?
         if choice is random.choice:
-            self.__choice = _choice
+            self._choice = _choice
         else:
-            self.__choice = choice
+            self._choice = choice
 
     @property
     def choice(self):
         """The `choice` function used by the cache."""
-        return self.__choice
+        return self._choice
 
     def popitem(self):
         """Remove and return a random `(key, value)` pair."""
         try:
-            key = self.__choice(list(self))
+            key = self._choice(list(self))
         except IndexError:
             msg = '%s is empty' % self.__class__.__name__
             raise KeyError(msg) from None


### PR DESCRIPTION
This will make easier to customize the behavior of the cache classes when they're subclassed.

Currently, if someone wanted to customize the behavior of say the `popitem` method, they will not be able to access these "protected" attributes which is meant to override the default popitem implementation.