### PR TITLE
func, decorators: prefer values already in the cache in races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 docs/_build/
 .pytest_cache/
+.vscode/

--- a/cachetools/decorators.py
+++ b/cachetools/decorators.py
@@ -21,10 +21,9 @@ def cached(cache, key=hashkey, lock=None):
                     pass  # key not found
                 v = func(*args, **kwargs)
                 try:
-                    cache[k] = v
+                    return cache.setdefault(k, v)
                 except ValueError:
-                    pass  # value too large
-                return v
+                    return v  # value too large; just return it without caching
         else:
             def wrapper(*args, **kwargs):
                 k = key(*args, **kwargs)
@@ -36,10 +35,9 @@ def cached(cache, key=hashkey, lock=None):
                 v = func(*args, **kwargs)
                 try:
                     with lock:
-                        cache[k] = v
+                        return cache.setdefault(k, v)
                 except ValueError:
-                    pass  # value too large
-                return v
+                    return v  # value too large; just return it without caching
         return functools.update_wrapper(wrapper, func)
     return decorator
 
@@ -62,10 +60,9 @@ def cachedmethod(cache, key=hashkey, lock=None):
                     pass  # key not found
                 v = method(self, *args, **kwargs)
                 try:
-                    c[k] = v
+                    return c.setdefault(k, v)
                 except ValueError:
-                    pass  # value too large
-                return v
+                    return v  # value too large; just return it without caching
         else:
             def wrapper(self, *args, **kwargs):
                 c = cache(self)
@@ -80,9 +77,8 @@ def cachedmethod(cache, key=hashkey, lock=None):
                 v = method(self, *args, **kwargs)
                 try:
                     with lock(self):
-                        c[k] = v
+                        return c.setdefault(k, v)
                 except ValueError:
-                    pass  # value too large
-                return v
+                    return v  # value too large; just return it without caching
         return functools.update_wrapper(wrapper, method)
     return decorator

--- a/cachetools/func.py
+++ b/cachetools/func.py
@@ -65,10 +65,9 @@ def _cache(cache, typed):
             v = func(*args, **kwargs)
             try:
                 with lock:
-                    cache[k] = v
+                    return cache.setdefault(k, v)
             except ValueError:
-                pass  # value too large
-            return v
+                return v  # value too large; just return it without caching
 
         def cache_info():
             with lock:


### PR DESCRIPTION
This change updates the behavior of the cache decorators to prefer to
return the value *already in the cache* when the backing function is
called simultaneously from two separate threads. Previously, if two
threads raced to the cache, each would get the version of the cached
value calculated by its own thread, and the first's value would be
immediately evicted by the second.

In cases where caches are used to manage expensive resources, this could
result in two separate expensive objects hanging around the system
at the same time. With this change, there is only one long-lived object
exposed to callers, and the transient second object created by the race
can be immediately collected by the runtime.