### PR TITLE
replace all instances of RLock with Lock.

### DIFF
--- a/cachetools/func.py
+++ b/cachetools/func.py
@@ -7,9 +7,9 @@ import random
 import time
 
 try:
-    from threading import RLock
+    from threading import Lock
 except ImportError:  # pragma: no cover
-    from dummy_threading import RLock
+    from dummy_threading import Lock
 
 from . import keys
 from .lfu import LFUCache
@@ -50,7 +50,7 @@ def _cache(cache, typed):
 
     def decorator(func):
         key = keys.typedkey if typed else keys.hashkey
-        lock = RLock()
+        lock = Lock()
         stats = [0, 0]
 
         def wrapper(*args, **kwargs):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -211,7 +211,7 @@ often called with the same arguments:
    implementing the `context manager`_ protocol.  Any access to the
    cache will then be nested in a ``with lock:`` statement.  This can
    be used for synchronizing thread access to the cache by providing a
-   :class:`threading.RLock` instance, for example.
+   :class:`threading.Lock` instance, for example.
 
    .. note::
 
@@ -231,10 +231,10 @@ often called with the same arguments:
 
    .. testcode::
 
-      from threading import RLock
+      from threading import Lock
 
       cache = LRUCache(maxsize=32)
-      lock = RLock()
+      lock = Lock()
 
       @cached(cache, lock=lock)
       def get_pep(num):


### PR DESCRIPTION
Since this code doesn't re-enter its own locks (itself a bad practice),
there is no need for reentrant locks here, either in our own code,
or in callers’ code to set up locks. This change replaces `Rlock` with
plain `Lock` across both the code and docs.