### PR TITLE
Drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-- 3.5
 - 3.6
 - 3.7
 - 3.8

--- a/cachetools/cache.py
+++ b/cachetools/cache.py
@@ -1,7 +1,7 @@
 from collections.abc import MutableMapping
 
 
-class _DefaultSize(object):
+class _DefaultSize:
 
     __slots__ = ()
 
@@ -32,7 +32,7 @@ class Cache(MutableMapping):
         self.__maxsize = maxsize
 
     def __repr__(self):
-        return '%s(%r, maxsize=%r, currsize=%r)' % (
+        return '{}({!r}, maxsize={!r}, currsize={!r})'.format(
             self.__class__.__name__,
             list(self.__data.items()),
             self.__maxsize,

--- a/cachetools/fifo.py
+++ b/cachetools/fifo.py
@@ -26,6 +26,6 @@ class FIFOCache(Cache):
         try:
             key = next(iter(self.__order))
         except StopIteration:
-            raise KeyError('%s is empty' % type(self).__name__) from None
+            raise KeyError(f'{type(self).__name__} is empty') from None
         else:
             return (key, self.pop(key))

--- a/cachetools/ttl.py
+++ b/cachetools/ttl.py
@@ -4,7 +4,7 @@ import time
 from .cache import Cache
 
 
-class _Link(object):
+class _Link:
 
     __slots__ = ('key', 'expire', 'next', 'prev')
 
@@ -22,7 +22,7 @@ class _Link(object):
         next.prev = prev
 
 
-class _Timer(object):
+class _Timer:
 
     def __init__(self, timer):
         self.__timer = timer
@@ -144,7 +144,7 @@ class TTLCache(Cache):
     def currsize(self):
         with self.__timer as time:
             self.expire(time)
-            return super(TTLCache, self).currsize
+            return super().currsize
 
     @property
     def timer(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,7 @@ def get_version():
     import pathlib
 
     cp = configparser.ConfigParser()
-    # Python 3.5 ConfigParser does not accept Path as filename
-    cp.read(str(pathlib.Path(__file__).parent.parent / "setup.cfg"))
+    cp.read(pathlib.Path(__file__).parent.parent / "setup.cfg")
     return cp["metadata"]["version"]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 
 
-class CacheTestMixin(object):
+class CacheTestMixin:
 
     Cache = None
 

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -3,7 +3,7 @@ import unittest
 import cachetools.func
 
 
-class DecoratorTestMixin(object):
+class DecoratorTestMixin:
 
     def decorator(self, maxsize, **kwargs):
         return self.DECORATOR(maxsize, **kwargs)

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -4,7 +4,7 @@ import unittest
 from cachetools import LRUCache, cachedmethod, keys
 
 
-class Cached(object):
+class Cached:
 
     def __init__(self, cache, count=0):
         self.cache = cache
@@ -27,7 +27,7 @@ class Cached(object):
         raise TypeError('unhashable type')
 
 
-class Locked(object):
+class Locked:
 
     def __init__(self, cache):
         self.cache = cache

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -4,7 +4,7 @@ import cachetools
 import cachetools.keys
 
 
-class DecoratorTestMixin(object):
+class DecoratorTestMixin:
 
     def cache(self, minsize):
         raise NotImplementedError
@@ -77,7 +77,7 @@ class DecoratorTestMixin(object):
         self.assertEqual(len(cache), 3)
 
     def test_decorator_lock(self):
-        class Lock(object):
+        class Lock:
 
             count = 0
 
@@ -116,7 +116,7 @@ class CacheWrapperTest(unittest.TestCase, DecoratorTestMixin):
         self.assertEqual(len(cache), 0)
 
     def test_zero_size_cache_decorator_lock(self):
-        class Lock(object):
+        class Lock:
 
             count = 0
 


### PR DESCRIPTION
Python 3.5 is after EOL. This drops its support and upgrades to Python 3.6+ features, such as f-strings and Path in ConfigParser.