### PR TITLE
Allow versions of python higher than 3.5 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = ~= 3.5
+python_requires = >= 3.5
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Currently, poetry will choke if you try to install cachetools on a major version other than python 3.5