### PR TITLE
Fix cache with variable result.

### DIFF
--- a/src/cachetools/decorators.py
+++ b/src/cachetools/decorators.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 
 from .keys import hashkey
@@ -20,7 +21,7 @@ def cached(cache, key=hashkey, lock=None):
             def wrapper(*args, **kwargs):
                 k = key(*args, **kwargs)
                 try:
-                    return cache[k]
+                    return copy.deepcopy(cache[k])
                 except KeyError:
                     pass  # key not found
                 v = func(*args, **kwargs)
@@ -28,7 +29,7 @@ def cached(cache, key=hashkey, lock=None):
                     cache[k] = v
                 except ValueError:
                     pass  # value too large
-                return v
+                return copy.deepcopy(v)
 
         else:
 
@@ -36,14 +37,14 @@ def cached(cache, key=hashkey, lock=None):
                 k = key(*args, **kwargs)
                 try:
                     with lock:
-                        return cache[k]
+                        return copy.deepcopy(cache[k])
                 except KeyError:
                     pass  # key not found
                 v = func(*args, **kwargs)
                 # in case of a race, prefer the item already in the cache
                 try:
                     with lock:
-                        return cache.setdefault(k, v)
+                        return copy.deepcopy(cache.setdefault(k, v))
                 except ValueError:
                     return v  # value too large
 
@@ -67,7 +68,7 @@ def cachedmethod(cache, key=hashkey, lock=None):
                     return method(self, *args, **kwargs)
                 k = key(*args, **kwargs)
                 try:
-                    return c[k]
+                    return copy.deepcopy(c[k])
                 except KeyError:
                     pass  # key not found
                 v = method(self, *args, **kwargs)
@@ -75,7 +76,7 @@ def cachedmethod(cache, key=hashkey, lock=None):
                     c[k] = v
                 except ValueError:
                     pass  # value too large
-                return v
+                return copy.deepcopy(v)
 
         else:
 
@@ -86,14 +87,14 @@ def cachedmethod(cache, key=hashkey, lock=None):
                 k = key(*args, **kwargs)
                 try:
                     with lock(self):
-                        return c[k]
+                        return copy.deepcopy(c[k])
                 except KeyError:
                     pass  # key not found
                 v = method(self, *args, **kwargs)
                 # in case of a race, prefer the item already in the cache
                 try:
                     with lock(self):
-                        return c.setdefault(k, v)
+                        return copy.deepcopy(c.setdefault(k, v))
                 except ValueError:
                     return v  # value too large
 

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -21,6 +21,10 @@ class Cached:
         self.count += 1
         return count
 
+    @cachedmethod(operator.attrgetter("cache"))
+    def get_variable_result(self, *args, **kwargs):
+        return [0]
+
     # https://github.com/tkem/cachetools/issues/107
     def __hash__(self):
         raise TypeError("unhashable type")
@@ -163,3 +167,11 @@ class CachedMethodTest(unittest.TestCase):
         self.assertEqual(cached.get(1), 5)
         self.assertEqual(cached.get(1.0), 7)
         self.assertEqual(cached.get(1.0), 9)
+
+    def test_variable_result(self):
+        cached = Cached(LRUCache(maxsize=2))
+        tmp_result = cached.get_variable_result(0)
+        self.assertEqual(tmp_result, [0])
+        tmp_result.append(1)
+        self.assertEqual(tmp_result, [0, 1])
+        self.assertEqual(cached.get_variable_result(0), [0])

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -15,6 +15,9 @@ class DecoratorTestMixin:
             self.count = 0
         return self.count
 
+    def variable_result_func(self, *args, **kwargs):
+        return [1]
+
     def test_decorator(self):
         cache = self.cache(2)
         wrapper = cachetools.cached(cache)(self.func)
@@ -133,6 +136,20 @@ class CacheWrapperTest(unittest.TestCase, DecoratorTestMixin):
         self.assertEqual(wrapper(0), 0)
         self.assertEqual(len(cache), 0)
         self.assertEqual(Lock.count, 2)
+
+    def test_variable_result(self):
+        cache = self.cache(2)
+        wrapper = cachetools.cached(cache)(self.variable_result_func)
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(wrapper.__wrapped__, self.variable_result_func)
+        tmp_result = wrapper(1)
+        self.assertEqual(tmp_result, [1])
+        self.assertEqual(len(cache), 1)
+
+        # update tmp_result
+        tmp_result.append(2)
+        self.assertEqual(tmp_result, [1, 2])
+        self.assertEqual(wrapper(1), [1])
 
 
 class DictWrapperTest(unittest.TestCase, DecoratorTestMixin):


### PR DESCRIPTION
### the result in cache can not be changed i think. so if the cached function return a variable result, in python it means the cache save is the result reference, it can be change by post process

- before fix
```python
In [1]: from cachetools import cached, LRUCache

In [2]: @cached(cache=LRUCache(maxsize=32))
   ...: def func(*args, **kwargs):
   ...:     print(args, kwargs)
   ...:     return [1,2,3]
   ...:

In [3]: res = func(1)
(1,) {}

In [4]: res
Out[4]: [1, 2, 3]

In [5]: res.append(4)

In [6]: func(1)
Out[6]: [1, 2, 3, 4]
```

- after fix
```python
In [1]: from cachetools import cached, LRUCache

In [2]: @cached(cache=LRUCache(maxsize=32))
   ...: def func(*args, **kwargs):
   ...:     print(args, kwargs)
   ...:     return [1,2,3]
   ...:

In [3]: res = func(1)
(1,) {}

In [4]: res
Out[4]: [1, 2, 3]

In [5]: res.append(5)

In [6]: func(1)
Out[6]: [1, 2, 3]

In [7]: res
Out[7]: [1, 2, 3, 5]
```