### PR TITLE
Add option `exclusive` to TTLCache

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,20 +111,22 @@ computed when the item is inserted into the cache.
    an alternative function that returns an arbitrary element from a
    non-empty sequence.
 
-.. autoclass:: TTLCache(maxsize, ttl, timer=time.monotonic, getsizeof=None)
-   :members: popitem, timer, ttl
+.. autoclass:: TTLCache(maxsize, ttl, timer=time.perf_counter, getsizeof=None, *, exclusive=False)
+   :members: popitem, timer, ttl, exclusive
 
    This class associates a time-to-live value with each item.  Items
    that expire because they have exceeded their time-to-live will be
-   no longer accessible, and will be removed eventually.  If no
-   expired items are there to remove, the least recently used items
-   will be discarded first to make space when necessary.
+   no longer accessible, and will be removed eventually. The optional
+   argument `exclusive` indicates whether to expire a time when it
+   reaches the exact point of its lifetime. If no expired items are
+   there to remove, the least recently used items will be discarded
+   first to make space when necessary.
 
    By default, the time-to-live is specified in seconds and
-   :func:`time.monotonic` is used to retrieve the current time.  A
+   :func:`time.perf_counter` is used to retrieve the current time. A
    custom `timer` function can be supplied if needed.
 
-   .. method:: expire(self, time=None)
+   .. method:: expire(self, time=None, exclusive=None)
 
       Expired items will be removed from a cache only at the next
       mutating operation, e.g. :meth:`__setitem__` or
@@ -133,7 +135,8 @@ computed when the item is inserted into the cache.
       have expired by `time`, so garbage collection is free to reuse
       their memory.  If `time` is :const:`None`, this removes all
       items that have expired by the current value returned by
-      :attr:`timer`.
+      :attr:`timer`. If `exclusive` is :const:`None`, the value from
+      the instance property will be used.
 
 
 Extending cache classes
@@ -509,7 +512,7 @@ all the decorators in this module are thread-safe by default.
    algorithm.
 
 .. decorator:: ttl_cache(user_function)
-               ttl_cache(maxsize=128, ttl=600, timer=time.monotonic, typed=False)
+               ttl_cache(maxsize=128, ttl=600, timer=time.perf_counter, typed=False, *, exclusive=False)
 
    Decorator to wrap a function with a memoizing callable that saves
    up to `maxsize` results based on a Least Recently Used (LRU)

--- a/src/cachetools/func.py
+++ b/src/cachetools/func.py
@@ -38,8 +38,8 @@ class _UnboundCache(dict):
 
 
 class _UnboundTTLCache(TTLCache):
-    def __init__(self, ttl, timer):
-        TTLCache.__init__(self, math.inf, ttl, timer)
+    def __init__(self, ttl, timer, *, exclusive):
+        TTLCache.__init__(self, math.inf, ttl, timer, exclusive=exclusive)
 
     @property
     def maxsize(self):
@@ -163,14 +163,14 @@ def rr_cache(maxsize=128, choice=random.choice, typed=False):
         return _cache(RRCache(maxsize, choice), typed)
 
 
-def ttl_cache(maxsize=128, ttl=600, timer=time.monotonic, typed=False):
+def ttl_cache(maxsize=128, ttl=600, timer=time.perf_counter, typed=False, *, exclusive=False):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Least Recently Used (LRU)
     algorithm with a per-item time-to-live (TTL) value.
     """
     if maxsize is None:
-        return _cache(_UnboundTTLCache(ttl, timer), typed)
+        return _cache(_UnboundTTLCache(ttl, timer, exclusive=exclusive), typed)
     elif callable(maxsize):
-        return _cache(TTLCache(128, ttl, timer), typed)(maxsize)
+        return _cache(TTLCache(128, ttl, timer, exclusive=exclusive), typed)(maxsize)
     else:
-        return _cache(TTLCache(maxsize, ttl, timer), typed)
+        return _cache(TTLCache(maxsize, ttl, timer, exclusive=exclusive), typed)


### PR DESCRIPTION
Add option `exclusive` to `TTLCache` to decide whether to expire the item when it reaches the exact point of its lifetime. (Ref https://github.com/tkem/cachetools/issues/219#issuecomment-917680687)

For example, by default (`exclusive=False` the current behavior), suppose an item is inserted at `10s` and the `ttl=5.0`, then it's still in the cache at `15s` (**INCLUSIVE**) and will be expired at `15s + \epsilon`.

With `exclusive=True`, the item will be in the cache at `15s - \epsilon` and be expired at `15s` (**EXCLUSIVE**) in the above example.

**NOTE:** As we only support Python 3.5+ now, the default timer in this PR has been changed to `time.perf_counter` (introduced in Python 3.3) to have a more precise time resolution. (Ref [Python Clocks Explained](https://www.webucator.com/article/python-clocks-explained) and [`perf_counter` vs. `process_time`](https://stackoverflow.com/questions/52222002/what-is-the-difference-between-time-perf-counter-and-time-process-time/52228375))