### PR TITLE
stacklevel 2 warnings

### DIFF
--- a/src/cachetools/cache.py
+++ b/src/cachetools/cache.py
@@ -3,5 +3,7 @@ import warnings
 from . import Cache
 
 warnings.warn(
-    "cachetools.cache is deprecated, please use cachetools.Cache", DeprecationWarning
+    "cachetools.cache is deprecated, please use cachetools.Cache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/fifo.py
+++ b/src/cachetools/fifo.py
@@ -3,5 +3,7 @@ import warnings
 from . import FIFOCache
 
 warnings.warn(
-    "cachetools.fifo is deprecated, please use cachetools.FIFOCache", DeprecationWarning
+    "cachetools.fifo is deprecated, please use cachetools.FIFOCache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/lfu.py
+++ b/src/cachetools/lfu.py
@@ -3,5 +3,7 @@ import warnings
 from . import LFUCache
 
 warnings.warn(
-    "cachetools.lfu is deprecated, please use cachetools.LFUCache", DeprecationWarning
+    "cachetools.lfu is deprecated, please use cachetools.LFUCache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/lru.py
+++ b/src/cachetools/lru.py
@@ -3,5 +3,7 @@ import warnings
 from . import LRUCache
 
 warnings.warn(
-    "cachetools.lru is deprecated, please use cachetools.LRUCache", DeprecationWarning
+    "cachetools.lru is deprecated, please use cachetools.LRUCache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/mru.py
+++ b/src/cachetools/mru.py
@@ -3,5 +3,7 @@ import warnings
 from . import MRUCache
 
 warnings.warn(
-    "cachetools.mru is deprecated, please use cachetools.MRUCache", DeprecationWarning
+    "cachetools.mru is deprecated, please use cachetools.MRUCache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/rr.py
+++ b/src/cachetools/rr.py
@@ -3,5 +3,7 @@ import warnings
 from . import RRCache
 
 warnings.warn(
-    "cachetools.rr is deprecated, please use cachetools.RRCache", DeprecationWarning
+    "cachetools.rr is deprecated, please use cachetools.RRCache",
+    DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/cachetools/ttl.py
+++ b/src/cachetools/ttl.py
@@ -3,5 +3,7 @@ import warnings
 from . import TTLCache
 
 warnings.warn(
-    "cachetools.ttl is deprecated, please use cachetools.TTLCache", DeprecationWarning
+    "cachetools.ttl is deprecated, please use cachetools.TTLCache",
+    DeprecationWarning,
+    stacklevel=2,
 )


### PR DESCRIPTION
Use `stacklevel=2` for deprecation warnings, so the source/line number of user code is indicated, instead of the source/line of the library itself.

```
$ cat user_code.py 
# in user_code.py
from cachetools.ttl import TTLCache
```

With this:

```
python3 -Wall user_code.py
/Users/wim/git/cachetools/user_code.py:2: DeprecationWarning: cachetools.ttl is deprecated, please use cachetools.TTLCache
  from cachetools.ttl import TTLCache
```

Without this:

```
$ python3 -Wall user_code.py
/Users/wim/git/cachetools/src/cachetools/ttl.py:5: DeprecationWarning: cachetools.ttl is deprecated, please use cachetools.TTLCache
  warnings.warn(
```