### PR TITLE
Fix #222: Add support for async cache decorators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+unrelease
+==========
+
+- Add async support to decorators
+
 v4.2.4 (2021-09-30)
 ===================
 

--- a/tests/test_aio_function.py
+++ b/tests/test_aio_function.py
@@ -1,0 +1,104 @@
+import cachetools
+
+import pytest
+
+
+async def target(val):
+    return val
+
+
+@pytest.mark.asyncio
+async def test_no_cache():
+    cache = None  # In this case we expect simple passthrough
+    wrapper = cachetools.cached(cache)(target)
+    assert await wrapper(0) == 0
+    assert await wrapper(1) == 1
+
+
+@pytest.mark.asyncio
+async def test_decorator():
+    cache = {}
+    wrapper = cachetools.cached(cache)(target)
+
+    assert len(cache) == 0
+    assert wrapper.__wrapped__ == target
+
+    assert await wrapper(0) == 0
+    assert len(cache) == 1
+    assert cachetools.keys.hashkey(0) in cache
+    assert cachetools.keys.hashkey(1) not in cache
+    assert cachetools.keys.hashkey(1.0) not in cache
+
+    assert await wrapper(1) == 1
+    assert len(cache) == 2
+    assert cachetools.keys.hashkey(0) in cache
+    assert cachetools.keys.hashkey(1) in cache
+    assert cachetools.keys.hashkey(1.0) in cache
+
+    assert await wrapper(1) == 1
+    assert len(cache) == 2
+
+    assert await wrapper(1.0) == 1.0
+    assert len(cache) == 2
+
+    assert await wrapper(1.0) == 1.0
+    assert len(cache) == 2
+
+
+@pytest.mark.asyncio
+async def test_decorator_typed():
+    cache = dict()
+    key = cachetools.keys.typedkey
+    wrapper = cachetools.cached(cache, key=key)(target)
+
+    assert len(cache) == 0
+    assert wrapper.__wrapped__ == target
+
+    assert await wrapper(0) == 0
+    assert len(cache) == 1
+    assert cachetools.keys.typedkey(0) in cache
+    assert cachetools.keys.typedkey(1) not in cache
+    assert cachetools.keys.typedkey(1.0) not in cache
+
+    assert await wrapper(1) == 1
+    assert len(cache) == 2
+    assert cachetools.keys.typedkey(0) in cache
+    assert cachetools.keys.typedkey(1) in cache
+    assert cachetools.keys.typedkey(1.0) not in cache
+
+    assert await wrapper(1) == 1
+    assert len(cache) == 2
+
+    assert await wrapper(1.0) == 1.0
+    assert len(cache) == 3
+    assert cachetools.keys.typedkey(0) in cache
+    assert cachetools.keys.typedkey(1) in cache
+    assert cachetools.keys.typedkey(1.0) in cache
+
+    assert await wrapper(1.0) == 1.0
+    assert len(cache) == 3
+
+
+@pytest.mark.asyncio
+async def test_decorator_lock():
+    class Lock:
+
+        count = 0
+
+        def __enter__(self):
+            Lock.count += 1
+
+        def __exit__(self, *exc):
+            pass
+
+    cache = {}
+    wrapper = cachetools.cached(cache, lock=Lock())(target)
+
+    assert len(cache) == 0
+    assert wrapper.__wrapped__ == target
+    assert await wrapper(0) == 0
+    assert Lock.count == 2
+    assert await wrapper(1) == 1
+    assert Lock.count == 4
+    assert await wrapper(1) == 1
+    assert Lock.count == 5

--- a/tests/test_aio_method.py
+++ b/tests/test_aio_method.py
@@ -1,0 +1,184 @@
+import operator
+
+from cachetools import LRUCache, cachedmethod, keys
+
+import pytest
+
+
+class Cached:
+    def __init__(self, cache, count=0):
+        self.cache = cache
+        self.count = count
+
+    @cachedmethod(operator.attrgetter("cache"))
+    async def get(self, value):
+        count = self.count
+        self.count += 1
+        return count
+
+    @cachedmethod(operator.attrgetter("cache"), key=keys.typedkey)
+    async def get_typed(self, value):
+        count = self.count
+        self.count += 1
+        return count
+
+    # https://github.com/tkem/cachetools/issues/107
+    def __hash__(self):
+        raise TypeError("unhashable type")
+
+
+class Locked:
+    def __init__(self, cache):
+        self.cache = cache
+        self.count = 0
+
+    @cachedmethod(operator.attrgetter("cache"), lock=lambda self: self)
+    async def get(self, value):
+        return self.count
+
+    def __enter__(self):
+        self.count += 1
+
+    def __exit__(self, *exc):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_dict():
+    cached = Cached({})
+
+    assert await cached.get(0) == 0
+    assert await cached.get(1) == 1
+    assert await cached.get(1) == 1
+    assert await cached.get(1.0) == 1
+    assert await cached.get(1.0) == 1
+
+    cached.cache.clear()
+    assert await cached.get(1) == 2
+
+
+@pytest.mark.asyncio
+async def test_typed_dict():
+    cached = Cached(LRUCache(maxsize=2))
+
+    assert await cached.get_typed(0) == 0
+    assert await cached.get_typed(1) == 1
+    assert await cached.get_typed(1) == 1
+    assert await cached.get_typed(1.0) == 2
+    assert await cached.get_typed(1.0) == 2
+    assert await cached.get_typed(0.0) == 3
+    assert await cached.get_typed(0) == 4
+
+
+@pytest.mark.asyncio
+async def test_lru():
+    cached = Cached(LRUCache(maxsize=2))
+
+    assert await cached.get(0) == 0
+    assert await cached.get(1) == 1
+    assert await cached.get(1) == 1
+    assert await cached.get(1.0) == 1
+    assert await cached.get(1.0) == 1
+
+    cached.cache.clear()
+    assert await cached.get(1) == 2
+
+
+@pytest.mark.asyncio
+async def test_typed_lru():
+    cached = Cached(LRUCache(maxsize=2))
+
+    assert await cached.get_typed(0) == 0
+    assert await cached.get_typed(1) == 1
+    assert await cached.get_typed(1) == 1
+    assert await cached.get_typed(1.0) == 2
+    assert await cached.get_typed(1.0) == 2
+    assert await cached.get_typed(0.0) == 3
+    assert await cached.get_typed(0) == 4
+
+
+@pytest.mark.asyncio
+async def test_nospace():
+    cached = Cached(LRUCache(maxsize=0))
+
+    assert await cached.get(0) == 0
+    assert await cached.get(1) == 1
+    assert await cached.get(1) == 2
+    assert await cached.get(1.0) == 3
+    assert await cached.get(1.0) == 4
+
+
+@pytest.mark.asyncio
+async def test_nocache():
+    cached = Cached(None)
+
+    assert await cached.get(0) == 0
+    assert await cached.get(1) == 1
+    assert await cached.get(1) == 2
+    assert await cached.get(1.0) == 3
+    assert await cached.get(1.0) == 4
+
+
+@pytest.mark.asyncio
+async def test_weakref():
+    import weakref
+    import fractions
+    import gc
+
+    # in Python 3.4, `int` does not support weak references even
+    # when subclassed, but Fraction apparently does...
+    class Int(fractions.Fraction):
+        def __add__(self, other):
+            return Int(fractions.Fraction.__add__(self, other))
+
+    cached = Cached(weakref.WeakValueDictionary(), count=Int(0))
+
+    assert await cached.get(0) == 0
+    gc.collect()
+    assert await cached.get(0) == 1
+
+    ref = await cached.get(1)
+    assert ref == 2
+    assert await cached.get(1) == 2
+    assert await cached.get(1.0) == 2
+
+    ref = await cached.get_typed(1)
+    assert ref == 3
+    assert await cached.get_typed(1) == 3
+    assert await cached.get_typed(1.0) == 4
+
+    cached.cache.clear()
+    assert await cached.get(1) == 5
+
+
+@pytest.mark.asyncio
+async def test_locked_dict():
+    cached = Locked({})
+
+    assert await cached.get(0) == 1
+    assert await cached.get(1) == 3
+    assert await cached.get(1) == 3
+    assert await cached.get(1.0) == 3
+    assert await cached.get(2.0) == 7
+
+
+@pytest.mark.asyncio
+async def test_locked_nocache():
+    cached = Locked(None)
+
+    assert await cached.get(0) == 0
+    assert await cached.get(1) == 0
+    assert await cached.get(1) == 0
+    assert await cached.get(1.0) == 0
+    assert await cached.get(1.0) == 0
+
+
+@pytest.mark.asyncio
+async def test_locked_nospace():
+    cached = Locked(LRUCache(maxsize=0))
+
+    assert await cached.get(0) == 1
+    assert await cached.get(1) == 3
+    assert await cached.get(1) == 5
+    assert await cached.get(1.0) == 7
+    assert await cached.get(1.0) == 9

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = check-manifest,docs,doctest,flake8,py
 deps =
     pytest
     pytest-cov
+    pytest-asyncio
 commands =
     py.test --basetemp={envtmpdir} --cov=cachetools {posargs}
 


### PR DESCRIPTION
This branch extends the @cached and @cachedmethod decorators to support async, using the same signature.

This is achieved using the `inspect` module of the standard library to determine if the decorated function/method is a coroutine.

A few items that might be of further interest:

- This branch adds a dev dependency on `pytest-asyncio` (in order to test the new async path)
- Unfortunately, pytest doesn't know how to deal with classes extending `unittest.TestCase`. Instead, this branch introduces a slight departure in testing syntax, using top-level `async def` functions instead of a testcase subclass. The end result is the same, however.
- A small refactoring in the decorator logic was done to reduce code duplication (which would be further increased by this branch, adding another axis to the decorator matrix: lock/no lock and sync/async)
- Test coverage remains 100%

On a personal note: thanks a lot for the great work on this module thus far. It is not often that I am positively surprised with the attention to quality in "open source projects", and adding a feature to such a well-tested project was a bliss. Thanks!