### PR TITLE
Delay setting timer default value until construction

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -327,7 +327,10 @@ class _TimedCache(Cache):
         def __getattr__(self, name):
             return getattr(self.__timer, name)
 
-    def __init__(self, maxsize, timer=time.monotonic, getsizeof=None):
+    def __init__(self, maxsize, timer=None, getsizeof=None):
+        if timer is None:
+            timer = time.monotonic
+
         Cache.__init__(self, maxsize, getsizeof)
         self.__timer = _TimedCache._Timer(timer)
 
@@ -390,7 +393,10 @@ class TTLCache(_TimedCache):
             prev.next = next
             next.prev = prev
 
-    def __init__(self, maxsize, ttl, timer=time.monotonic, getsizeof=None):
+    def __init__(self, maxsize, ttl, timer=None, getsizeof=None):
+        if timer is None:
+            timer = time.monotonic
+
         _TimedCache.__init__(self, maxsize, timer, getsizeof)
         self.__root = root = TTLCache._Link()
         root.prev = root.next = root
@@ -515,7 +521,10 @@ class TLRUCache(_TimedCache):
         def __lt__(self, other):
             return self.expires < other.expires
 
-    def __init__(self, maxsize, ttu, timer=time.monotonic, getsizeof=None):
+    def __init__(self, maxsize, ttu, timer=None, getsizeof=None):
+        if timer is None:
+            timer = time.monotonic
+
         _TimedCache.__init__(self, maxsize, timer, getsizeof)
         self.__items = collections.OrderedDict()
         self.__order = []

--- a/src/cachetools/func.py
+++ b/src/cachetools/func.py
@@ -104,11 +104,14 @@ def rr_cache(maxsize=128, choice=random.choice, typed=False):
         return _cache(RRCache(maxsize, choice), maxsize, typed)
 
 
-def ttl_cache(maxsize=128, ttl=600, timer=time.monotonic, typed=False):
+def ttl_cache(maxsize=128, ttl=600, timer=None, typed=False):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Least Recently Used (LRU)
     algorithm with a per-item time-to-live (TTL) value.
     """
+    if timer is None:
+        timer = time.monotonic
+
     if maxsize is None:
         return _cache(_UnboundTTLCache(ttl, timer), None, typed)
     elif callable(maxsize):


### PR DESCRIPTION
This PR moves the binding of the time-aware cached implementation's `timer`s until they are constructed instead of when `cachetools` is first imported.

This makes it much easier when writing tests to mock/fake out `time.monotonic` (e.g. via unittest.mock or stuff like https://github.com/spulec/freezegun or https://github.com/adamchainz/time-machine).

This _can_ still be accomplished today by manually setting `timer`, but requires callers to do:

```python
@TTLCache(..., timer=lambda: time.monotonic())
def do_work()
    ...
```

for each cache and probably leave a comment explaining why you're doing this xD

---
Also thanks for cachetools in general, its been super great :D