### PR TITLE
Configure flake8 to include -- not exclude -- chosen paths

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ where = src
 
 [flake8]
 max-line-length = 80
-exclude = .git, .tox, build
 select = C, E, F, W, B, B950, I, N
 # F401: imported but unused (submodule shims)
 # E501: line too long (black)

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,5 @@ deps =
     flake8-bugbear
     flake8-import-order
 commands =
-    flake8
+    flake8 setup.py docs/conf.py src/cachetools/ tests/
 skip_install = true


### PR DESCRIPTION
After cloning the cachetools repo, I created a virtual environment named `.venv/` and ran the test suite. The flake8 test failed because it scanned the entire `.venv/` subdirectory, which was not listed as an excluded directory.

To prevent this type of failure, this PR switches from an exclusion list to an include list.

Note that flake8 only supports exclusions as a configurable option; inclusions must be specified on the command line.