### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR introduces a Dependabot configuration that will keep GitHub action versions updated on a monthly basis (if updates are available).

If this PR merges, you can expect Dependabot to immediately open a PR to update `actions/checkout@v3` to `v4`, which was recently released.

Thanks for your work on cachetools!