### PR TITLE
Refactor default lock

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -720,24 +720,6 @@ def cached(cache, key=keys.hashkey, lock=None, info=False):
                 def cache_clear():
                     pass
 
-            elif lock is None:
-
-                def wrapper(*args, **kwargs):
-                    k = key(*args, **kwargs)
-                    try:
-                        return cache[k]
-                    except KeyError:
-                        pass  # key not found
-                    v = func(*args, **kwargs)
-                    try:
-                        cache[k] = v
-                    except ValueError:
-                        pass  # value too large
-                    return v
-
-                def cache_clear():
-                    cache.clear()
-
             else:
 
                 def wrapper(*args, **kwargs):

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -115,7 +115,6 @@ class DecoratorTestMixin:
 
         self.assertIs(wrapper.cache, cache)
         self.assertIs(wrapper.cache_key, cachetools.keys.hashkey)
-        # self.assertIs(wrapper.cache_lock, None)
         self.assertIsInstance(wrapper.cache_lock, cachetools._NoLock)
 
     def test_decorator_attributes_lock(self):

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -115,7 +115,8 @@ class DecoratorTestMixin:
 
         self.assertIs(wrapper.cache, cache)
         self.assertIs(wrapper.cache_key, cachetools.keys.hashkey)
-        self.assertIs(wrapper.cache_lock, None)
+        # self.assertIs(wrapper.cache_lock, None)
+        self.assertIsInstance(wrapper.cache_lock, cachetools._NoLock)
 
     def test_decorator_attributes_lock(self):
         cache = self.cache(2)
@@ -226,7 +227,7 @@ class NoneWrapperTest(unittest.TestCase):
 
         self.assertIs(wrapper.cache, None)
         self.assertIs(wrapper.cache_key, cachetools.keys.hashkey)
-        self.assertIs(wrapper.cache_lock, None)
+        self.assertIsInstance(wrapper.cache_lock, cachetools._NoLock)
 
     def test_decorator_clear(self):
         wrapper = cachetools.cached(None)(self.func)

--- a/tests/test_cachedmethod.py
+++ b/tests/test_cachedmethod.py
@@ -1,5 +1,5 @@
 import unittest
-
+import cachetools
 from cachetools import LRUCache, cachedmethod, keys
 
 
@@ -203,7 +203,7 @@ class CachedMethodTest(unittest.TestCase):
 
         self.assertIs(cached.get.cache(cached), cache)
         self.assertIs(cached.get.cache_key, keys.methodkey)
-        self.assertIs(cached.get.cache_lock, None)
+        self.assertIsInstance(cached.get.cache_lock, cachetools._NoLock)
 
     def test_attributes_lock(self):
         cache = {}


### PR DESCRIPTION
### Description

Make `cached` and `cachedmethod` functions more concise by introducing default no-op `NoLock` class thus eliminating duplication in `elif lock is None:` branches.


### Testing

```python
import timeit
setup = """
from cachetools import cached
import time

@cached(cache={})
def dummy_func():
    time.sleep(0.1)
    return 10 ** 10
"""

s = """
dummy_func()
"""

print(timeit.timeit(setup=setup, stmt=s, number=100_000))
# 0.14263679101713933
# 0.15603854099754244
```

There is no significant overhead with running no-op locking/unlocking (only 1/100th of a second) and taking into account that caching is always applied to already "heavy" functions it's negligible.