### PR TITLE
Convert signatures to keyword-only arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72408109
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -18,9 +26,8 @@ jobs:
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ matrix.python }}
-          allow-prereleases: true
-      - run: python -m pip install coverage tox
-      - run: python -m tox
+      - run: pip install coverage tox
+      - run: tox
       - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           name: ${{ matrix.python }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ inserted into the cache.
    synchronized, e.g. by using one of the memoizing decorators with a
    suitable `lock` object.
 
-.. autoclass:: Cache(maxsize, getsizeof=None)
+.. autoclass:: Cache(maxsize, *, getsizeof=None)
    :members: currsize, getsizeof, maxsize
 
    This class discards arbitrary items using :meth:`popitem` to make
@@ -80,25 +80,25 @@ inserted into the cache.
    additionally need to override :meth:`__getitem__`,
    :meth:`__setitem__` and :meth:`__delitem__`.
 
-.. autoclass:: FIFOCache(maxsize, getsizeof=None)
+.. autoclass:: FIFOCache(maxsize, *, getsizeof=None)
    :members: popitem
 
    This class evicts items in the order they were added to make space
    when necessary.
 
-.. autoclass:: LFUCache(maxsize, getsizeof=None)
+.. autoclass:: LFUCache(maxsize, *, getsizeof=None)
    :members: popitem
 
    This class counts how often an item is retrieved, and discards the
    items used least often to make space when necessary.
 
-.. autoclass:: LRUCache(maxsize, getsizeof=None)
+.. autoclass:: LRUCache(maxsize, *, getsizeof=None)
    :members: popitem
 
    This class discards the least recently used items first to make
    space when necessary.
 
-.. autoclass:: RRCache(maxsize, choice=random.choice, getsizeof=None)
+.. autoclass:: RRCache(maxsize, *, choice=random.choice, getsizeof=None)
    :members: choice, popitem
 
    This class randomly selects candidate items and discards them to
@@ -109,7 +109,7 @@ inserted into the cache.
    an alternative function that returns an arbitrary element from a
    non-empty sequence.
 
-.. autoclass:: TTLCache(maxsize, ttl, timer=time.monotonic, getsizeof=None)
+.. autoclass:: TTLCache(maxsize, *, ttl, timer=time.monotonic, getsizeof=None)
    :members: popitem, timer, ttl
 
    This class associates a time-to-live value with each item.  Items
@@ -151,7 +151,7 @@ inserted into the cache.
 
       :returns: An iterable of expired `(key, value)` pairs.
 
-.. autoclass:: TLRUCache(maxsize, ttu, timer=time.monotonic, getsizeof=None)
+.. autoclass:: TLRUCache(maxsize, *, ttu, timer=time.monotonic, getsizeof=None)
    :members: popitem, timer, ttu
 
    Similar to :class:`TTLCache`, this class also associates an
@@ -299,7 +299,7 @@ often called with the same arguments:
    >>> fib(42)
    267914296
 
-.. decorator:: cached(cache, key=cachetools.keys.hashkey, lock=None, info=False)
+.. decorator:: cached(cache, *, key=cachetools.keys.hashkey, lock=None, info=False)
 
    Decorator to wrap a function with a memoizing callable that saves
    results in a cache.
@@ -462,7 +462,7 @@ often called with the same arguments:
           print(e, "-", _get_pep_wrapped.cache_info())
 
 
-.. decorator:: cachedmethod(cache, key=cachetools.keys.methodkey, lock=None)
+.. decorator:: cachedmethod(cache, *, key=cachetools.keys.methodkey, lock=None)
 
    Decorator to wrap a class or instance method with a memoizing
    callable that saves results in a (possibly shared) cache.
@@ -656,35 +656,35 @@ all the decorators in this module are thread-safe by default.
 
 
 .. decorator:: fifo_cache(user_function)
-               fifo_cache(maxsize=128, typed=False)
+               fifo_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False)
 
    Decorator that wraps a function with a memoizing callable that
    saves up to `maxsize` results based on a First In First Out
    (FIFO) algorithm.
 
 .. decorator:: lfu_cache(user_function)
-               lfu_cache(maxsize=128, typed=False)
+               lfu_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False)
 
    Decorator that wraps a function with a memoizing callable that
    saves up to `maxsize` results based on a Least Frequently Used
    (LFU) algorithm.
 
 .. decorator:: lru_cache(user_function)
-               lru_cache(maxsize=128, typed=False)
+               lru_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False)
 
    Decorator that wraps a function with a memoizing callable that
    saves up to `maxsize` results based on a Least Recently Used (LRU)
    algorithm.
 
 .. decorator:: rr_cache(user_function)
-               rr_cache(maxsize=128, choice=random.choice, typed=False)
+               rr_cache(maxsize=128, *, choice=random.choice, typed=False, lock=None, condition=None, info=False)
 
    Decorator that wraps a function with a memoizing callable that
    saves up to `maxsize` results based on a Random Replacement (RR)
    algorithm.
 
 .. decorator:: ttl_cache(user_function)
-               ttl_cache(maxsize=128, ttl=600, timer=time.monotonic, typed=False)
+               ttl_cache(maxsize=128, *, ttl=600, timer=time.monotonic, typed=False, lock=None, condition=None, info=False)
 
    Decorator to wrap a function with a memoizing callable that saves
    up to `maxsize` results based on a Least Recently Used (LRU)

--- a/src/cachetools/_cachedmethod.py
+++ b/src/cachetools/_cachedmethod.py
@@ -3,7 +3,7 @@
 import weakref
 
 
-def _cachedmethod_condition(method, cache, key, lock, cond):
+def _cachedmethod_condition(*, method, cache, key, lock, condition):
     pending = weakref.WeakKeyDictionary()
 
     def wrapper(self, *args, **kwargs):
@@ -13,7 +13,7 @@ def _cachedmethod_condition(method, cache, key, lock, cond):
         k = key(self, *args, **kwargs)
         with lock(self):
             p = pending.setdefault(self, set())
-            cond(self).wait_for(lambda: k not in p)
+            condition(self).wait_for(lambda: k not in p)
             try:
                 return c[k]
             except KeyError:
@@ -29,7 +29,7 @@ def _cachedmethod_condition(method, cache, key, lock, cond):
         finally:
             with lock(self):
                 pending[self].remove(k)
-                cond(self).notify_all()
+                condition(self).notify_all()
 
     def cache_clear(self):
         c = cache(self)
@@ -41,7 +41,7 @@ def _cachedmethod_condition(method, cache, key, lock, cond):
     return wrapper
 
 
-def _cachedmethod_locked(method, cache, key, lock):
+def _cachedmethod_locked(*, method, cache, key, lock):
     def wrapper(self, *args, **kwargs):
         c = cache(self)
         if c is None:
@@ -70,7 +70,7 @@ def _cachedmethod_locked(method, cache, key, lock):
     return wrapper
 
 
-def _cachedmethod_unlocked(method, cache, key):
+def _cachedmethod_unlocked(*, method, cache, key):
     def wrapper(self, *args, **kwargs):
         c = cache(self)
         if c is None:
@@ -96,13 +96,18 @@ def _cachedmethod_unlocked(method, cache, key):
     return wrapper
 
 
-def _cachedmethod_wrapper(func, cache, key, lock=None, cond=None):
-    if cond is not None and lock is not None:
-        wrapper = _cachedmethod_condition(func, cache, key, lock, cond)
-    elif cond is not None:
-        wrapper = _cachedmethod_condition(func, cache, key, cond, cond)
+def _cachedmethod_wrapper(*, method, cache, key, lock=None, condition=None):
+    if condition is not None and lock is not None:
+        wrapper = _cachedmethod_condition(
+            method=method, cache=cache, key=key, lock=lock, condition=condition
+        )
+    elif condition is not None:
+        # passing lock=condition because _cachedmethod_condition does 'with lock(self)'
+        wrapper = _cachedmethod_condition(
+            method=method, cache=cache, key=key, lock=condition, condition=condition
+        )
     elif lock is not None:
-        wrapper = _cachedmethod_locked(func, cache, key, lock)
+        wrapper = _cachedmethod_locked(method=method, cache=cache, key=key, lock=lock)
     else:
-        wrapper = _cachedmethod_unlocked(func, cache, key)
+        wrapper = _cachedmethod_unlocked(method=method, cache=cache, key=key)
     return wrapper

--- a/src/cachetools/func.py
+++ b/src/cachetools/func.py
@@ -6,11 +6,7 @@ import functools
 import math
 import random
 import time
-
-try:
-    from threading import Condition
-except ImportError:  # pragma: no cover
-    from dummy_threading import Condition
+from threading import Condition, Lock
 
 from . import FIFOCache, LFUCache, LRUCache, RRCache, TTLCache
 from . import cached
@@ -18,88 +14,215 @@ from . import keys
 
 
 class _UnboundTTLCache(TTLCache):
-    def __init__(self, ttl, timer):
-        TTLCache.__init__(self, math.inf, ttl, timer)
+    def __init__(self, *, ttl, timer):
+        TTLCache.__init__(self, maxsize=math.inf, ttl=ttl, timer=timer)
 
     @property
     def maxsize(self):
         return None
 
 
-def _cache(cache, maxsize, typed):
+def _cache(*, cache, maxsize=128, typed=False, lock=None, condition=None, info=False):
+    if condition is None:
+        condition = Condition()
+
     def decorator(func):
         key = keys.typedkey if typed else keys.hashkey
-        wrapper = cached(cache=cache, key=key, condition=Condition(), info=True)(func)
+        wrapper = cached(
+            cache=cache, key=key, condition=condition, info=info, lock=lock
+        )(func)
         wrapper.cache_parameters = lambda: {"maxsize": maxsize, "typed": typed}
         return wrapper
 
     return decorator
 
 
-def fifo_cache(maxsize=128, typed=False):
+def fifo_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a First In First Out (FIFO)
     algorithm.
 
     """
     if maxsize is None:
-        return _cache({}, None, typed)
+        return _cache(
+            cache={},
+            maxsize=None,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
     elif callable(maxsize):
-        return _cache(FIFOCache(128), 128, typed)(maxsize)
+        return _cache(
+            cache=FIFOCache(maxsize=128),
+            maxsize=128,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )(maxsize)
     else:
-        return _cache(FIFOCache(maxsize), maxsize, typed)
+        return _cache(
+            cache=FIFOCache(maxsize=maxsize),
+            maxsize=maxsize,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
 
 
-def lfu_cache(maxsize=128, typed=False):
+def lfu_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Least Frequently Used (LFU)
     algorithm.
 
     """
     if maxsize is None:
-        return _cache({}, None, typed)
+        return _cache(
+            cache={},
+            maxsize=None,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
     elif callable(maxsize):
-        return _cache(LFUCache(128), 128, typed)(maxsize)
+        return _cache(
+            cache=LFUCache(maxsize=128),
+            maxsize=128,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )(maxsize)
     else:
-        return _cache(LFUCache(maxsize), maxsize, typed)
+        return _cache(
+            cache=LFUCache(maxsize=maxsize),
+            maxsize=maxsize,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
 
 
-def lru_cache(maxsize=128, typed=False):
+def lru_cache(maxsize=128, *, typed=False, lock=None, condition=None, info=False):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Least Recently Used (LRU)
     algorithm.
 
     """
     if maxsize is None:
-        return _cache({}, None, typed)
+        return _cache(
+            cache={},
+            maxsize=None,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
     elif callable(maxsize):
-        return _cache(LRUCache(128), 128, typed)(maxsize)
+        return _cache(
+            cache=LRUCache(maxsize=128),
+            maxsize=128,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )(maxsize)
     else:
-        return _cache(LRUCache(maxsize), maxsize, typed)
+        return _cache(
+            cache=LRUCache(maxsize=maxsize),
+            maxsize=maxsize,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
 
 
-def rr_cache(maxsize=128, choice=random.choice, typed=False):
+def rr_cache(
+    maxsize=128,
+    *,
+    choice=random.choice,
+    typed=False,
+    lock=None,
+    condition=None,
+    info=False
+):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Random Replacement (RR)
     algorithm.
 
     """
     if maxsize is None:
-        return _cache({}, None, typed)
+        return _cache(
+            cache={},
+            maxsize=None,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
     elif callable(maxsize):
-        return _cache(RRCache(128, choice), 128, typed)(maxsize)
+        return _cache(
+            cache=RRCache(maxsize=128, choice=choice),
+            maxsize=128,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )(maxsize)
     else:
-        return _cache(RRCache(maxsize, choice), maxsize, typed)
+        return _cache(
+            cache=RRCache(maxsize=maxsize, choice=choice),
+            maxsize=maxsize,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
 
 
-def ttl_cache(maxsize=128, ttl=600, timer=time.monotonic, typed=False):
+def ttl_cache(
+    maxsize=128,
+    *,
+    ttl=600,
+    timer=time.monotonic,
+    typed=False,
+    lock=None,
+    condition=None,
+    info=False
+):
     """Decorator to wrap a function with a memoizing callable that saves
     up to `maxsize` results based on a Least Recently Used (LRU)
     algorithm with a per-item time-to-live (TTL) value.
     """
     if maxsize is None:
-        return _cache(_UnboundTTLCache(ttl, timer), None, typed)
+        return _cache(
+            cache=_UnboundTTLCache(ttl=ttl, timer=timer),
+            maxsize=None,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )
     elif callable(maxsize):
-        return _cache(TTLCache(128, ttl, timer), 128, typed)(maxsize)
+        return _cache(
+            cache=TTLCache(maxsize=128, ttl=ttl, timer=timer),
+            maxsize=128,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )(maxsize)
     else:
-        return _cache(TTLCache(maxsize, ttl, timer), maxsize, typed)
+        return _cache(
+            cache=TTLCache(maxsize=maxsize, ttl=ttl, timer=timer),
+            maxsize=maxsize,
+            typed=typed,
+            lock=lock,
+            condition=condition,
+            info=info,
+        )

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -252,18 +252,6 @@ class CacheWrapperTest(unittest.TestCase, DecoratorTestMixin):
         self.assertEqual(wrapper.cache_info(), (0, 0, 2, 0))
         self.assertEqual(lock.count, 11)
 
-    def test_decorator_lock_info_deprecated(self):
-        cache = self.cache(2)
-        key = cachetools.keys.hashkey
-        lock = CountedLock()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            # passing `ìnfo` as positional parameter is deprecated
-            wrapper = cachetools.cached(cache, key, lock, True)(self.func)
-        self.assertEqual(len(w), 1)
-        self.assertIs(w[0].category, DeprecationWarning)
-        self.assertEqual(wrapper.cache_info(), (0, 0, 2, 0))
-
     def test_decorator_condition_info(self):
         cache = self.cache(2)
         lock = cond = CountedCondition()

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -5,7 +5,7 @@ import cachetools.func
 
 class DecoratorTestMixin:
     def decorator(self, maxsize, **kwargs):
-        return self.DECORATOR(maxsize, **kwargs)
+        return self.DECORATOR(maxsize, info=True, **kwargs)
 
     def test_decorator(self):
         cached = self.decorator(maxsize=2)(lambda n: n)

--- a/tests/test_tlru.py
+++ b/tests/test_tlru.py
@@ -25,7 +25,7 @@ class TLRUTestCache(TLRUCache):
         return math.inf
 
     def __init__(self, maxsize, ttu=default_ttu, **kwargs):
-        TLRUCache.__init__(self, maxsize, ttu, timer=Timer(), **kwargs)
+        TLRUCache.__init__(self, maxsize=maxsize, ttu=ttu, timer=Timer(), **kwargs)
 
 
 class TLRUCacheTest(unittest.TestCase, CacheTestMixin):

--- a/tox.ini
+++ b/tox.ini
@@ -18,15 +18,16 @@ skip_install = true
 
 [testenv:docs]
 deps =
-     sphinx
+    sphinx
 commands =
-     sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 [testenv:doctest]
 deps =
-     sphinx
+    sphinx
 commands =
-     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs {envtmpdir}/doctest
+    sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs {envtmpdir}/doctest
+skip_install = true
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Hi @tkem 👋 

Hoping this PR can land in v6 🤞

This PR:
- Reduces bug surface by using keyword-only arguments ([PEP-3102](https://peps.python.org/pep-3102/)) in most signatures.
- Makes `condition`, `lock`, `info` configurable for the `cachetools.func` module.
    - Switches from `info=True` default to `info=False` default analogous to the main module.
- Deprecates [`dummy_threading`](https://docs.python.org/3.8/library/dummy_threading.html) which has been unavailable since 3.7 (the minimum required version of cachetools in setup.cfg).
    - by the way, why is CI only running 3.9+?