### PR TITLE
Always OrderedDict

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -147,25 +147,17 @@ class Cache(collections.abc.MutableMapping):
 class FIFOCache(Cache):
     """First In First Out (FIFO) cache implementation."""
 
-    def __init__(self, maxsize, getsizeof=None):
-        Cache.__init__(self, maxsize, getsizeof)
-        self.__order = collections.OrderedDict()
-
     def __setitem__(self, key, value, cache_setitem=Cache.__setitem__):
         cache_setitem(self, key, value)
         try:
-            self.__order.move_to_end(key)
+            self.move_to_end(key)
         except KeyError:
-            self.__order[key] = None
-
-    def __delitem__(self, key, cache_delitem=Cache.__delitem__):
-        cache_delitem(self, key)
-        del self.__order[key]
+            self[key] = None
 
     def popitem(self):
         """Remove and return the `(key, value)` pair first inserted."""
         try:
-            key = next(iter(self.__order))
+            key = next(iter(self))
         except StopIteration:
             raise KeyError("%s is empty" % type(self).__name__) from None
         else:

--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -51,7 +51,7 @@ class Cache(collections.abc.MutableMapping):
             self.getsizeof = getsizeof
         if self.getsizeof is not Cache.getsizeof:
             self.__size = dict()
-        self.__data = dict()
+        self.__data = collections.OrderedDict()
         self.__currsize = 0
         self.__maxsize = maxsize
 
@@ -124,6 +124,9 @@ class Cache(collections.abc.MutableMapping):
         else:
             self[key] = value = default
         return value
+
+    def move_to_end(self, key):
+        self.__data.move_to_end(key)
 
     @property
     def maxsize(self):


### PR DESCRIPTION
- **Use OrderedDict always**
- **Simplify FIFO**

Please, see commit messages.

The same simplification could be applied to LRUCache.

I am not sure if this is a good change, just wondering if you have considered the option.
