### PR TITLE
Make cachetools.func thread-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
-      - run: python -m pip install coverage tox
-      - run: python -m tox
+      - run: pip install coverage tox
+      - run: tox
       - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           name: ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72408109
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -9,6 +13,7 @@ jobs:
   main:
     name: Python ${{ matrix.python }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -666,6 +666,10 @@ performance and clear the cache.  Please see the
 :func:`functools.lru_cache` documentation for details.  Also note that
 all the decorators in this module are thread-safe by default.
 
+.. note::
+
+   In contrast to the top-level classes, these decorators *are* thread-safe.
+   They instantiate a :class:`threading.Lock` before wrapping your function.
 
 .. decorator:: fifo_cache(user_function)
                fifo_cache(maxsize=128, typed=False)

--- a/src/cachetools/func.py
+++ b/src/cachetools/func.py
@@ -6,7 +6,7 @@ import functools
 import math
 import random
 import time
-from threading import Condition
+from threading import Condition, Lock
 
 from . import FIFOCache, LFUCache, LRUCache, RRCache, TTLCache
 from . import cached
@@ -25,7 +25,7 @@ class _UnboundTTLCache(TTLCache):
 def _cache(cache, maxsize, typed):
     def decorator(func):
         key = keys.typedkey if typed else keys.hashkey
-        wrapper = cached(cache=cache, key=key, condition=Condition(), info=True)(func)
+        wrapper = cached(cache=cache, key=key, lock=Lock(), info=True)(func)
         wrapper.cache_parameters = lambda: {"maxsize": maxsize, "typed": typed}
         return wrapper
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,15 +17,15 @@ skip_install = true
 
 [testenv:docs]
 deps =
-     sphinx
+    sphinx
 commands =
-     sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 [testenv:doctest]
 deps =
-     sphinx
+    sphinx
 commands =
-     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs {envtmpdir}/doctest
+    sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs {envtmpdir}/doctest
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
> `cachetools.func` intentionally follows `functools.lru_cache`, and tries to stay as simple as possible for the user

ref https://github.com/tkem/cachetools/pull/338#issuecomment-2784446274

Cherry-picked from #338, this PR makes `cachetools.func` thread-safe analogous to `functools.lru_cache` and omits the configurability part.