### PR TITLE
feat: update project URLs in pyproject.toml to show on pypi.org

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/tkem/cachetools/"
+Homepage = "https://cachetools.readthedocs.io/en/stable/"
+Documentation = "https://cachetools.readthedocs.io/en/stable/"
+Source = "https://github.com/tkem/cachetools/"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,12 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://cachetools.readthedocs.io/en/stable/"
+Homepage = "https://github.com/tkem/cachetools/"
 Documentation = "https://cachetools.readthedocs.io/en/stable/"
 Source = "https://github.com/tkem/cachetools/"
+Repository = "https://github.com/tkem/cachetools/"
+Issues = "https://github.com/tkem/cachetools/issues"
+Changelog = "https://github.com/tkem/cachetools/blob/master/CHANGELOG.rst"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
# Description

Would love to add these changes to the links on the pypi.org page. Let me know if I need to make any changes to get it merged to master. 😊

 **Added** 
- Documentation & Source links in pyproject.toml

**Changed** 
- Homepage link -> Documentation page in pyproject.toml

## Motivation and Context

I view these docs a lot and I would love to add the documentation link to the pypi.org page to decrease on the number of clicks I normally make to view the docs. Just for convenience.

## Has this been tested and documented?

Not sure how I would test this kind of an update but I am all ears!
