### PR TITLE
Fix FIFOCache update order

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -173,9 +173,7 @@ class FIFOCache(Cache):
 
     def __setitem__(self, key, value, cache_setitem=Cache.__setitem__):
         cache_setitem(self, key, value)
-        if key in self.__order:
-            self.__order.move_to_end(key)
-        else:
+        if key not in self.__order:
             self.__order[key] = None
 
     def __delitem__(self, key, cache_delitem=Cache.__delitem__):

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -63,6 +63,16 @@ class FIFOCacheTest(unittest.TestCase, CacheTestMixin):
         cache[1] = "updated"
         cache[3] = 3
 
-        self.assertEqual(cache[1], "updated")
+        self.assertEqual(cache[2], 2)
         self.assertIn(3, cache)
-        self.assertNotIn(2, cache)
+        self.assertNotIn(1, cache)
+
+    def test_fifo_update_existing_popitem(self):
+        cache = FIFOCache[int, int | str](maxsize=3)
+
+        cache[1] = 1
+        cache[2] = 2
+        cache[3] = 3
+        cache[1] = "updated"
+
+        self.assertEqual(cache.popitem(), (1, "updated"))


### PR DESCRIPTION
Fixes #395.

This fixes `FIFOCache` so updating an existing key does not change its FIFO insertion order.

Previously, assigning a new value to an existing key moved that key to the end of the internal order, causing a later insertion to evict the wrong item. The updated behavior keeps the original insertion order for existing keys while still adding new keys to the end.

Tests added/updated:
- updating an existing key preserves FIFO eviction order
- `popitem()` still returns the originally first inserted key after an update

Validation:
- `python -m pytest tests/test_fifo.py -q`
- `python -m pytest -q`
- `tox -e py -- tests/test_fifo.py`
- `tox -e py`
- `tox -e flake8,pyright`
- `git diff --check`

AI assistance:
I used ChatGPT/Codex to help identify this issue, inspect the existing implementation and tests, and prepare the local patch. I reviewed the final diff and validation results before submitting.
