### PR TITLE
Fix TLRUCache keeping stale value when overwriting a key with an expired value

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -625,10 +625,26 @@ class TLRUCache(_TimedCache):
         else:
             return cache_getitem(self, key)
 
-    def __setitem__(self, key, value, cache_setitem=Cache.__setitem__):
+    def __setitem__(
+        self,
+        key,
+        value,
+        cache_setitem=Cache.__setitem__,
+        cache_delitem=Cache.__delitem__,
+    ):
         with self.timer as time:
             expires = self.__ttu(key, value, time)
             if not (time < expires):
+                # The new value is already expired, so it is not stored.
+                # If the key still holds a previous (possibly still valid)
+                # value, drop it as well -- otherwise the assignment would
+                # be silently ignored and the stale value would persist.
+                try:
+                    self.__items.pop(key).removed = True
+                except KeyError:
+                    pass
+                else:
+                    cache_delitem(self, key)
                 return  # skip expired items
             self.expire(time)
             cache_setitem(self, key, value)

--- a/tests/test_tlru.py
+++ b/tests/test_tlru.py
@@ -144,6 +144,26 @@ class TLRUCacheTest(unittest.TestCase, CacheTestMixin):
         self.assertEqual(cache[4], 4)
         self.assertEqual(cache[5], 5)
 
+    def test_overwrite_existing_with_expired(self):
+        # Overwriting an existing key with an already-expired value must not
+        # silently retain the previous value: the assignment cannot store the
+        # new (dead-on-arrival) value, so the key has to be evicted instead.
+        def ttu(_k, value, t):
+            return t + value
+
+        cache = TLRUCache[int, int, int](maxsize=2, ttu=ttu, timer=Timer())
+        cache[1] = 5
+        self.assertEqual(cache[1], 5)
+        self.assertEqual(len(cache), 1)
+        self.assertEqual(cache.currsize, 1)
+
+        cache[1] = 0  # ttu -> t, i.e. not (t < t): immediately expired
+        self.assertNotIn(1, cache)
+        self.assertIsNone(cache.get(1))
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.currsize, 0)
+        self.assertEqual(set(cache), set())
+
     def test_ttu_expire(self):
         def ttu(_k, _v, t):
             return t + 3


### PR DESCRIPTION
Assigning an already-expired value to an *existing* key in a `TLRUCache` is silently swallowed: `__setitem__` returns early before storing the new value, but it leaves the previous entry in place. The cache then keeps returning the old value, even though the assignment should have replaced (or removed) it.

```python
from cachetools import TLRUCache
c = TLRUCache(maxsize=10, ttu=lambda k, v, now: now + v, timer=lambda: 0.0)
c['x'] = 5
c['x'] = 0          # ttu -> now, i.e. immediately expired
c['x']              # -> 5  (stale old value; expected: KeyError / absent)
'x' in c            # -> True
```

When the new value is dead-on-arrival, drop any existing entry for that key so it is evicted instead of retaining the stale value. New-key inserts of expired values remain a no-op as before. Added a regression test.