### PR TITLE
Reject negative cache item sizes

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -75,6 +75,8 @@ class Cache(collections.abc.MutableMapping):
     def __setitem__(self, key, value):
         maxsize = self.__maxsize
         size = self.getsizeof(value)
+        if size < 0:
+            raise ValueError("value size must be non-negative")
         if size > maxsize:
             raise ValueError("value too large")
         if key not in self.__data or self.__size[key] < size:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -284,6 +284,15 @@ class CacheTestMixin(_TestCaseProtocol):
     def test_getsizeof_param(self):
         self._test_getsizeof(self.Cache(maxsize=3, getsizeof=lambda x: x))
 
+    def test_getsizeof_negative(self):
+        cache = self.Cache(maxsize=3, getsizeof=lambda x: -1)
+
+        with self.assertRaises(ValueError):
+            cache[1] = 1
+
+        self.assertEqual(0, len(cache))
+        self.assertEqual(0, cache.currsize)
+
     def test_getsizeof_subclass(self):
         class Cache(self.Cache):
             @staticmethod


### PR DESCRIPTION
## What changed

`Cache.__setitem__()` now rejects negative values returned by `getsizeof()` before mutating cache state.

## Why

A custom `getsizeof` returning a negative number currently lets `currsize` become negative. That breaks the cache size invariant and can make later capacity checks behave incorrectly.

## Validation

- `PYTHONPATH=src python -m unittest tests.test_cache.CacheTest.test_getsizeof_negative`
- `PYTHONPATH=src python -m pytest tests -q`
- `python -m ruff check src\cachetools\__init__.py tests\__init__.py`
- `git diff --check`