### PR TITLE
Fix TLRUCache leaving a stale value readable after an expired-ttu overwrite

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -629,6 +629,13 @@ class TLRUCache(_TimedCache):
         with self.timer as time:
             expires = self.__ttu(key, value, time)
             if not (time < expires):
+                # Do not store an already-expired item, but make sure any
+                # previous value for this key is no longer accessible: a
+                # successful assignment must not leave the old value readable.
+                try:
+                    del self[key]
+                except KeyError:
+                    pass
                 return  # skip expired items
             self.expire(time)
             cache_setitem(self, key, value)

--- a/tests/test_tlru.py
+++ b/tests/test_tlru.py
@@ -214,6 +214,24 @@ class TLRUCacheTest(unittest.TestCase, CacheTestMixin):
         self.assertEqual(cache[1], None)
         self.assertEqual(1, len(cache))
 
+    def test_ttu_expired_overwrite_invalidates(self):
+        # Overwriting a live key with a value whose ttu is already in the past
+        # must not leave the previous value readable (the new item is skipped,
+        # but the old one must be invalidated).
+        cache = TLRUCache[int, int, int](
+            maxsize=2, ttu=lambda k, v, t: t + v, timer=Timer()
+        )
+        cache[1] = 5
+        self.assertEqual(cache[1], 5)
+        self.assertIn(1, cache)
+        cache[1] = 0  # ttu == now -> already expired, new item skipped
+        self.assertNotIn(1, cache)
+        self.assertEqual(cache.get(1), None)
+        self.assertEqual(0, len(cache))
+        # a later live assignment to the same key still works
+        cache[1] = 3
+        self.assertEqual(cache[1], 3)
+
     def test_ttu_atomic(self):
         cache = TLRUCache[int, int, int](
             maxsize=1, ttu=lambda k, v, t: t + 2, timer=Timer(auto=True)


### PR DESCRIPTION
Fixes #406.

## Problem
`TLRUCache.__setitem__` skips storing an item whose `ttu(key, value, now)` is already in the past. When the key already held a live value, the skip path returned without invalidating it, so the previous value stayed readable after an assignment that appeared to succeed (`key in cache` True, `cache[key]` returns the overwritten value). This diverges from `TTLCache` (store-then-expire; a `ttl=0` overwrite invalidates), and is a stale-read hazard in the documented value-derived-`ttu` pattern.

## Fix
On the skip path, drop any existing entry for the key before returning, reusing the class's own `__delitem__` (heap-safe: it marks the item removed, consistent with the existing "removing an existing item would break the heap structure" handling):
```python
if not (time < expires):
    try:
        del self[key]
    except KeyError:
        pass
    return  # skip expired items
```

## Tests
Adds `test_ttu_expired_overwrite_invalidates`: a live key overwritten with an already-expired ttu is no longer present or readable, `len` is correct, and a later live assignment to the same key still works. The test fails on `master` and passes with the fix. Full suite: 284 passed.

## Notes
Prepared with AI assistance and independently verified before submission (fresh clone, reproduced on HEAD, fix reviewed for heap/`expire()`/`currsize` consistency, full suite green, and a 30k-op randomized invariant stress with mixed positive/negative ttus held).