### PR TITLE
Fix Cache.__setitem__ over-eviction when growing an existing key with getsizeof

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -79,9 +79,18 @@ class Cache(collections.abc.MutableMapping):
             raise ValueError("value size must be non-negative")
         if size > maxsize:
             raise ValueError("value too large")
-        if key not in self.__data or self.__size[key] < size:
-            while self.__currsize + size > maxsize:
-                self.popitem()
+        # If the key is already present, its current size is already
+        # included in currsize, so only the *additional* space (size -
+        # old size) has to be reserved -- not the full new size.  Note
+        # that popitem() may evict the very key being updated, turning
+        # this into a fresh insert; re-checking membership on each
+        # iteration keeps the reservation correct in that case.  See
+        # https://github.com/tkem/cachetools/issues/405.
+        while (
+            self.__currsize - (self.__size[key] if key in self.__data else 0) + size
+            > maxsize
+        ):
+            self.popitem()
         if key in self.__data:
             diffsize = size - self.__size[key]
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -301,6 +301,33 @@ class CacheTestMixin(_TestCaseProtocol):
 
         self._test_getsizeof(Cache(maxsize=3))
 
+    def test_getsizeof_grow_existing_fits(self):
+        # Growing an existing key must not evict other entries as long
+        # as the updated cache still fits within maxsize; the result
+        # must match the equivalent "delete followed by insert".
+        # https://github.com/tkem/cachetools/issues/405
+        cache = self.Cache(maxsize=10, getsizeof=lambda v: v)
+        cache["a"] = 3
+        cache["b"] = 3
+        self.assertEqual(6, cache.currsize)
+
+        cache["b"] = 7  # a(3) + b(7) == 10 == maxsize, so it still fits
+
+        self.assertEqual(2, len(cache))
+        self.assertEqual({"a", "b"}, set(cache))
+        self.assertEqual(3, cache["a"])
+        self.assertEqual(7, cache["b"])
+        self.assertEqual(10, cache.currsize)
+
+        # the equivalent delete-then-insert keeps the same entries
+        equivalent = self.Cache(maxsize=10, getsizeof=lambda v: v)
+        equivalent["a"] = 3
+        equivalent["b"] = 3
+        del equivalent["b"]
+        equivalent["b"] = 7
+        self.assertEqual(set(cache), set(equivalent))
+        self.assertEqual(cache.currsize, equivalent.currsize)
+
     def test_clear(self):
         cache = self.Cache(maxsize=2)
         cache.update({1: 1, 2: 2})


### PR DESCRIPTION
Fixes #405

## Description

`Cache.__setitem__` (the base method inherited by all cache types) over-evicts when an existing key's value grows and a `getsizeof` is set. When updating an existing key, `self.__currsize` already includes that key's *old* size, but the eviction loop reserved the *full* new size (`self.__currsize + size > maxsize`). This double-counts the old size and calls `popitem()` even when the updated cache would still fit within `maxsize`, silently evicting an unrelated live entry.

## Root cause

```python
# before
if key not in self.__data or self.__size[key] < size:
    while self.__currsize + size > maxsize:   # reserves the full new size
        self.popitem()
```

For an existing key, the correct amount to reserve is the *delta* (`size - old size`) — the value is already computed a few lines below (`diffsize`) for the accounting update, but it was not applied to the eviction reservation.

## Fix

Reserve only the additional space needed for an existing key:

```python
while (
    self.__currsize - (self.__size[key] if key in self.__data else 0) + size
    > maxsize
):
    self.popitem()
```

The reserved amount is re-checked on every iteration because `popitem()` may evict the very key being updated (e.g. LRU/LFU/RR eviction order), turning the operation into a fresh insert. When that happens the subtracted term drops to `0` while `currsize` has already dropped by the old size, so the effective space required stays continuous and correct. `diffsize` is still recomputed from the final membership after the loop, keeping `currsize` accounting exact. This never exceeds `maxsize`, and a genuine grow that does not fit still evicts as before.

Result now matches the documented "delete followed by insert" equivalent:

```python
c = cachetools.LRUCache(maxsize=10, getsizeof=lambda v: v)
c["a"] = 3
c["b"] = 3
c["b"] = 7          # a(3) + b(7) == 10 == maxsize -> fits
dict(c)             # before: {'b': 7}   after: {'a': 3, 'b': 7}
```

## Added test

`CacheTestMixin.test_getsizeof_grow_existing_fits` in `tests/__init__.py`, so it runs against every cache class (`Cache`, `FIFOCache`, `LRUCache`, `LFUCache`, `RRCache`, `TTLCache`, `TLRUCache`). It asserts that growing a key which still fits evicts nothing and matches the delete-then-insert equivalent. The test fails on the unpatched code and passes with the fix.

Full suite: `python -m pytest -q` → 298 passed. `ruff check` and `ruff format --diff` are clean.