### PR TITLE
Fix Cache.__setitem__ over-evicting when growing an existing key with getsizeof

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ v7.1.6 (2026-07-24)
 
 - Minor style improvements to keep ``ruff`` happy.
 
+- Fix ``Cache.__setitem__`` over-evicting when updating an existing
+  key with a custom ``getsizeof`` function.
+
 
 v7.1.5 (2026-07-23)
 ===================

--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -80,8 +80,11 @@ class Cache(collections.abc.MutableMapping):
         if size > maxsize:
             raise ValueError("value too large")
         if key not in self.__data or self.__size[key] < size:
-            while self.__currsize + size > maxsize:
+            oldsize = self.__size[key] if key in self.__data else 0
+            while self.__currsize - oldsize + size > maxsize:
                 self.popitem()
+                if key not in self.__data:
+                    oldsize = 0
         if key in self.__data:
             diffsize = size - self.__size[key]
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -352,6 +352,33 @@ class CacheTestMixin(_TestCaseProtocol):
         self.assertEqual(1, len(cache))
         self.assertEqual(4, cache.currsize)
 
+    def test_setitem_getsizeof_grow_existing(self):
+        # Regression test for issue #405: growing an existing key should not
+        # over-evict when the updated cache still fits within maxsize.
+        cache = self.Cache(maxsize=10, getsizeof=lambda x: x)
+        cache["a"] = 3
+        cache["b"] = 3
+        self.assertEqual(6, cache.currsize)
+
+        cache["b"] = 7  # final size 3+7=10 fits in maxsize
+        self.assertIn("a", cache)
+        self.assertIn("b", cache)
+        self.assertEqual(7, cache["b"])
+        self.assertEqual(10, cache.currsize)
+
+    def test_setitem_getsizeof_grow_needs_eviction(self):
+        # Growing an existing key beyond available space must still evict.
+        cache = self.Cache(maxsize=10, getsizeof=lambda x: x)
+        cache["a"] = 3
+        cache["b"] = 3
+        self.assertEqual(6, cache.currsize)
+
+        cache["b"] = 9  # needs 3+9=12 > 10, so "a" must be evicted
+        self.assertNotIn("a", cache)
+        self.assertIn("b", cache)
+        self.assertEqual(9, cache["b"])
+        self.assertEqual(9, cache.currsize)
+
     def test_pickle(self):
         import pickle
 


### PR DESCRIPTION
Fixes #405

## Problem

`Cache.__setitem__` reserves space for the *full* new size when updating an existing key, instead of only the *additional* size needed. The eviction loop condition `self.__currsize + size > maxsize` double-counts the old key's size (already in `currsize`), causing unnecessary eviction of unrelated entries.

## Reproduction

```python
import cachetools
c = cachetools.LRUCache(maxsize=10, getsizeof=lambda v: v)
c["a"] = 3
c["b"] = 3          # currsize == 6
c["b"] = 7          # final size 3+7=10 fits, but "a" is silently evicted
print(dict(c))      # {'b': 7}  — expected {'a': 3, 'b': 7}
```

## Root cause

The eviction loop uses `self.__currsize + size > maxsize` but `currsize` already includes the old size of the key being updated. The correct reservation is `currsize - oldsize + newsize`.

## Fix

Subtract the existing key's size from `currsize` in the eviction condition. Handle the edge case where `popitem()` evicts the key being updated by resetting `oldsize` to 0 and continuing the loop.

## Validation

- Added two regression tests (`test_setitem_getsizeof_grow_existing`, `test_setitem_getsizeof_grow_needs_eviction`)
- Full test suite: **305 passed**, 0 failed
- `ruff check` passes on all changed files