### PR TITLE
Reject negative maxsize in Cache.__init__

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -50,6 +50,8 @@ class Cache(collections.abc.MutableMapping):
     __size = _DefaultSize()
 
     def __init__(self, maxsize, getsizeof=None):
+        if maxsize < 0:
+            raise ValueError("maxsize must be non-negative")
         if getsizeof:
             self.getsizeof = getsizeof
         if self.getsizeof is not Cache.getsizeof:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Container, Iterable
 from typing import Any, Protocol
 
@@ -40,6 +41,29 @@ class CacheTestMixin(_TestCaseProtocol):
         self.assertEqual(1, cache.getsizeof(""))
         self.assertEqual(1, cache.getsizeof(0))
         self.assertTrue(repr(cache).startswith(cache.__class__.__name__))
+
+    def test_maxsize_negative(self):
+        with self.assertRaises(ValueError):
+            self.Cache(maxsize=-1)
+
+        with self.assertRaises(ValueError):
+            self.Cache(maxsize=-math.inf)
+
+    def test_maxsize_zero(self):
+        cache = self.Cache(maxsize=0)
+
+        self.assertEqual(0, cache.maxsize)
+        with self.assertRaises(ValueError):
+            cache[1] = 1
+        self.assertEqual(0, len(cache))
+        self.assertEqual(0, cache.currsize)
+
+    def test_maxsize_infinite(self):
+        cache = self.Cache(maxsize=math.inf)
+
+        cache.update((i, i) for i in range(100))
+        self.assertEqual(100, len(cache))
+        self.assertEqual(100, cache.currsize)
 
     def test_insert(self):
         cache = self.Cache(maxsize=2)


### PR DESCRIPTION
# Description

`Cache.__init__()` now rejects a negative `maxsize` with
`ValueError: maxsize must be non-negative`, instead of building a cache
that can never hold anything.

`maxsize=0` and `maxsize=math.inf` are unchanged — see "Choice of `< 0`
vs `<= 0`" below.

## Motivation and Context

This is item 1 of "Code — Potential Issues" in `.github/copilot-review.md`
(dated 2026-05-22), still unfixed as of v7.1.7:

> | 1 | Low | `Cache.__init__` | `maxsize` is not validated. Negative values cause confusing `popitem` errors at insertion time rather than a clear early `ValueError`. Docs note `maxsize` must be positive, but code does not enforce it. |

The constructor accepts any `maxsize`, so the mistake is not reported
where it is made. On `master`:

```python
>>> import cachetools
>>> c = cachetools.LRUCache(maxsize=-1)
>>> c
LRUCache({}, maxsize=-1, currsize=0)
>>> c["a"] = 1
Traceback (most recent call last):
  ...
ValueError: value too large
```

The error names the *value* as the problem, but the value is a perfectly
ordinary `1`; the actual mistake is the `maxsize` passed several lines
(or several modules) earlier.

Because `maxsize` is stored by `Cache.__init__()`, every subclass
inherits this: `Cache`, `FIFOCache`, `LFUCache`, `LRUCache`, `RRCache`,
`TTLCache` and `TLRUCache` all construct happily with `maxsize=-1`.

The worse case is via the decorators, where there is no error at all.
`@cached` and `@cachedmethod` catch `ValueError` from `__setitem__()`
and fall through to the wrapped function, so a negative `maxsize`
silently turns memoization off:

```python
>>> @cachetools.cached(cachetools.LRUCache(maxsize=-1))
... def f(x):
...     print("computing", x)
...     return x * 2
>>> f(1); f(1)
computing 1
2
computing 1     # never cached, no error, no warning
2
```

That is easy to reach in practice from a computed cache size
(`maxsize=budget - reserved`) or a plain sign typo, and it fails as a
silent performance regression rather than as an exception.

The fix validates in `Cache.__init__()`, which is the one place every
cache class funnels through, and mirrors the non-negative check already
performed on `getsizeof()` results in `Cache.__setitem__()`:

```python
if size < 0:
    raise ValueError("value size must be non-negative")
```

## Choice of `< 0` vs `<= 0`

The docs note says `maxsize` "must be a positive number", which would
suggest rejecting `0` too, but the code and the test suite treat
`maxsize=0` as a supported zero-size cache — it is exercised by
`test_pickle_maxsize` in `CacheTestMixin` and by the `test_nospace`
cases in `test_cached.py` / `test_cachedmethod.py`. Using `<= 0` breaks
27 existing tests, so this PR rejects only negative values and leaves
`maxsize=0` alone. I have not touched the docs note; tightening or
relaxing that wording seemed like your call rather than mine.

`math.inf` is likewise unaffected, including the `_UnboundTTLCache`
path in `cachetools.func` used for `maxsize=None`.

## Related Issue

There is no open issue for this one — the finding is recorded in the
repo's own `.github/copilot-review.md`, quoted above. Happy to file an
issue first if you'd prefer to keep the tracker as the single record.

## Has this been tested and documented?

Three tests added to `CacheTestMixin` in `tests/__init__.py`, so they
run against all seven cache classes:

- `test_maxsize_negative` — `-1` and `-math.inf` are rejected
- `test_maxsize_zero` — `maxsize=0` still constructs and still raises
  `ValueError` only on insert (regression guard for the `<= 0` variant)
- `test_maxsize_infinite` — `maxsize=math.inf` still grows unbounded

Fail before the fix (`src/cachetools/__init__.py` reverted, tests kept):

```
FAILED tests/test_cache.py::CacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_fifo.py::FIFOCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_lfu.py::LFUCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_lru.py::LRUCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_rr.py::RRCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_tlru.py::TLRUCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
FAILED tests/test_ttl.py::TTLCacheTest::test_maxsize_negative - AssertionError: ValueError not raised
7 failed, 14 passed, 312 deselected in 0.13s
```

Pass after, with the full suite green (312 before, 333 after = 3 new
tests x 7 cache classes):

```
$ python -m pytest tests/ -q
333 passed in 5.01s
```

`ruff check`, `ruff format --diff`, `pyright` (0 errors) and the
`sphinx -b doctest` build (58 doctests) are all clean on Python 3.13.

## Deliberately not changed

- No `CHANGELOG.rst` entry — there is no unreleased section, and recent
  contributed fixes (#401, #408) left the changelog to the release
  commit. Happy to add one if you want it in the PR.
- `maxsize=None` still raises `TypeError` rather than `ValueError`, now
  at construction time instead of on first insert. Giving it a dedicated
  message felt like a separate change; the `cachetools.func` decorators
  that accept `None` intercept it before it reaches `Cache.__init__()`
  and are unaffected.
- No changes to the type stubs — the signature is unchanged.
