### PR TITLE
Reject a negative ttl on TTLCache

### DIFF
--- a/src/cachetools/__init__.py
+++ b/src/cachetools/__init__.py
@@ -468,6 +468,8 @@ class TTLCache(_TimedCache):
             next.prev = prev
 
     def __init__(self, maxsize, ttl, timer=time.monotonic, getsizeof=None):
+        if ttl < 0:
+            raise ValueError("ttl must be non-negative")
         _TimedCache.__init__(self, maxsize, timer, getsizeof)
         self.__root = root = TTLCache._Link()
         root.prev = root.next = root

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -28,6 +28,10 @@ class TTLTestCache(TTLCache):
 class TTLCacheTest(unittest.TestCase, CacheTestMixin):
     Cache = TTLTestCache
 
+    def test_ttl_negative(self):
+        with self.assertRaises(ValueError):
+            TTLCache(maxsize=2, ttl=-1)
+
     def test_ttl(self):
         cache = TTLCache[int, int, int](maxsize=2, ttl=2, timer=Timer())
         self.assertEqual(0, cache.timer())


### PR DESCRIPTION
`maxsize=-1` already raises. `ttl=-1` was accepted and expired every item immediately because `expires = now + ttl` is in the past.